### PR TITLE
Add data models for User, Group, Link, Tag, and APIKey

### DIFF
--- a/cmd/shorty-server/main.go
+++ b/cmd/shorty-server/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mikepea/shorty/pkg/shorty/database"
+	"github.com/mikepea/shorty/pkg/shorty/models"
 )
 
 func main() {
@@ -19,6 +20,12 @@ func main() {
 	if err := database.Connect(dbPath); err != nil {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}
+
+	// Run auto-migrations
+	if err := models.AutoMigrate(database.GetDB()); err != nil {
+		log.Fatalf("Failed to run migrations: %v", err)
+	}
+	log.Println("Database migrations completed")
 
 	// Set up Gin router
 	r := gin.Default()

--- a/pkg/shorty/models/api_key.go
+++ b/pkg/shorty/models/api_key.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// APIKey represents an API key for programmatic access
+type APIKey struct {
+	ID          uint           `gorm:"primarykey" json:"id"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	UserID      uint           `gorm:"not null;index" json:"user_id"`
+	KeyHash     string         `gorm:"not null" json:"-"`
+	KeyPrefix   string         `gorm:"not null" json:"key_prefix"` // First few chars for identification
+	Description string         `json:"description"`
+	LastUsedAt  *time.Time     `json:"last_used_at"`
+	CreatedByID uint           `gorm:"not null" json:"created_by_id"`
+
+	// Relationships
+	User      User `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	CreatedBy User `gorm:"foreignKey:CreatedByID" json:"created_by,omitempty"`
+}

--- a/pkg/shorty/models/group.go
+++ b/pkg/shorty/models/group.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Group represents a group that owns links
+// Users can belong to multiple groups, and each user has a personal group
+type Group struct {
+	ID          uint           `gorm:"primarykey" json:"id"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	Name        string         `gorm:"not null" json:"name"`
+	Description string         `json:"description"`
+
+	// Relationships
+	Members []GroupMembership `gorm:"foreignKey:GroupID" json:"members,omitempty"`
+	Links   []Link            `gorm:"foreignKey:GroupID" json:"links,omitempty"`
+}

--- a/pkg/shorty/models/group_membership.go
+++ b/pkg/shorty/models/group_membership.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// GroupRole represents a user's role within a specific group
+type GroupRole string
+
+const (
+	GroupRoleAdmin  GroupRole = "admin"
+	GroupRoleMember GroupRole = "member"
+)
+
+// GroupMembership represents the many-to-many relationship between users and groups
+type GroupMembership struct {
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	UserID    uint           `gorm:"not null;uniqueIndex:idx_user_group" json:"user_id"`
+	GroupID   uint           `gorm:"not null;uniqueIndex:idx_user_group" json:"group_id"`
+	Role      GroupRole      `gorm:"type:varchar(20);default:'member'" json:"role"`
+
+	// Relationships
+	User  User  `gorm:"foreignKey:UserID" json:"user,omitempty"`
+	Group Group `gorm:"foreignKey:GroupID" json:"group,omitempty"`
+}

--- a/pkg/shorty/models/link.go
+++ b/pkg/shorty/models/link.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Link represents a shortened URL/bookmark
+type Link struct {
+	ID          uint           `gorm:"primarykey" json:"id"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	GroupID     uint           `gorm:"not null;index" json:"group_id"`
+	CreatedByID uint           `gorm:"not null" json:"created_by_id"`
+	Slug        string         `gorm:"uniqueIndex;not null" json:"slug"`
+	URL         string         `gorm:"not null" json:"url"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	IsPublic    bool           `gorm:"default:false" json:"is_public"`
+	IsUnread    bool           `gorm:"default:true" json:"is_unread"`
+	ClickCount  uint           `gorm:"default:0" json:"click_count"`
+
+	// Relationships
+	Group     Group    `gorm:"foreignKey:GroupID" json:"group,omitempty"`
+	CreatedBy User     `gorm:"foreignKey:CreatedByID" json:"created_by,omitempty"`
+	Tags      []Tag    `gorm:"many2many:link_tags;" json:"tags,omitempty"`
+}

--- a/pkg/shorty/models/models.go
+++ b/pkg/shorty/models/models.go
@@ -1,0 +1,20 @@
+package models
+
+import "gorm.io/gorm"
+
+// AllModels returns all models for migration
+func AllModels() []interface{} {
+	return []interface{}{
+		&User{},
+		&Group{},
+		&GroupMembership{},
+		&Link{},
+		&Tag{},
+		&APIKey{},
+	}
+}
+
+// AutoMigrate runs GORM auto-migration for all models
+func AutoMigrate(db *gorm.DB) error {
+	return db.AutoMigrate(AllModels()...)
+}

--- a/pkg/shorty/models/models_test.go
+++ b/pkg/shorty/models/models_test.go
@@ -1,0 +1,170 @@
+package models
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+	return db
+}
+
+func TestAutoMigrate(t *testing.T) {
+	db := setupTestDB(t)
+
+	err := AutoMigrate(db)
+	if err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	// Verify tables exist by checking if we can query them
+	tables := []string{"users", "groups", "group_memberships", "links", "tags", "api_keys", "link_tags"}
+	for _, table := range tables {
+		if !db.Migrator().HasTable(table) {
+			t.Errorf("Expected table %s to exist", table)
+		}
+	}
+}
+
+func TestUserModel(t *testing.T) {
+	db := setupTestDB(t)
+	AutoMigrate(db)
+
+	user := User{
+		Email:        "test@example.com",
+		PasswordHash: "hashed_password",
+		Name:         "Test User",
+		SystemRole:   SystemRoleUser,
+	}
+
+	result := db.Create(&user)
+	if result.Error != nil {
+		t.Fatalf("Failed to create user: %v", result.Error)
+	}
+
+	if user.ID == 0 {
+		t.Error("Expected user ID to be set after create")
+	}
+
+	// Test unique email constraint
+	user2 := User{
+		Email:        "test@example.com",
+		PasswordHash: "another_hash",
+		Name:         "Another User",
+	}
+	result = db.Create(&user2)
+	if result.Error == nil {
+		t.Error("Expected error when creating user with duplicate email")
+	}
+}
+
+func TestGroupAndMembership(t *testing.T) {
+	db := setupTestDB(t)
+	AutoMigrate(db)
+
+	// Create user
+	user := User{
+		Email:        "test@example.com",
+		PasswordHash: "hashed_password",
+		Name:         "Test User",
+	}
+	db.Create(&user)
+
+	// Create group
+	group := Group{
+		Name:        "Test Group",
+		Description: "A test group",
+	}
+	db.Create(&group)
+
+	// Create membership
+	membership := GroupMembership{
+		UserID:  user.ID,
+		GroupID: group.ID,
+		Role:    GroupRoleAdmin,
+	}
+	result := db.Create(&membership)
+	if result.Error != nil {
+		t.Fatalf("Failed to create membership: %v", result.Error)
+	}
+
+	// Verify relationship
+	var loadedUser User
+	db.Preload("GroupMemberships").First(&loadedUser, user.ID)
+	if len(loadedUser.GroupMemberships) != 1 {
+		t.Errorf("Expected 1 membership, got %d", len(loadedUser.GroupMemberships))
+	}
+}
+
+func TestLinkWithTags(t *testing.T) {
+	db := setupTestDB(t)
+	AutoMigrate(db)
+
+	// Create user and group
+	user := User{Email: "test@example.com", PasswordHash: "hash", Name: "Test"}
+	db.Create(&user)
+	group := Group{Name: "Test Group"}
+	db.Create(&group)
+
+	// Create tags
+	tag1 := Tag{Name: "golang"}
+	tag2 := Tag{Name: "programming"}
+	db.Create(&tag1)
+	db.Create(&tag2)
+
+	// Create link with tags
+	link := Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "test-link",
+		URL:         "https://example.com",
+		Title:       "Example Site",
+		Tags:        []Tag{tag1, tag2},
+	}
+	result := db.Create(&link)
+	if result.Error != nil {
+		t.Fatalf("Failed to create link: %v", result.Error)
+	}
+
+	// Verify tags relationship
+	var loadedLink Link
+	db.Preload("Tags").First(&loadedLink, link.ID)
+	if len(loadedLink.Tags) != 2 {
+		t.Errorf("Expected 2 tags, got %d", len(loadedLink.Tags))
+	}
+}
+
+func TestSlugUniqueness(t *testing.T) {
+	db := setupTestDB(t)
+	AutoMigrate(db)
+
+	user := User{Email: "test@example.com", PasswordHash: "hash", Name: "Test"}
+	db.Create(&user)
+	group := Group{Name: "Test Group"}
+	db.Create(&group)
+
+	link1 := Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "unique-slug",
+		URL:         "https://example1.com",
+	}
+	db.Create(&link1)
+
+	link2 := Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "unique-slug",
+		URL:         "https://example2.com",
+	}
+	result := db.Create(&link2)
+	if result.Error == nil {
+		t.Error("Expected error when creating link with duplicate slug")
+	}
+}

--- a/pkg/shorty/models/tag.go
+++ b/pkg/shorty/models/tag.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Tag represents a tag that can be applied to links
+type Tag struct {
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	Name      string         `gorm:"uniqueIndex;not null" json:"name"`
+
+	// Relationships
+	Links []Link `gorm:"many2many:link_tags;" json:"links,omitempty"`
+}

--- a/pkg/shorty/models/user.go
+++ b/pkg/shorty/models/user.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// SystemRole represents a user's system-wide role
+type SystemRole string
+
+const (
+	SystemRoleAdmin SystemRole = "admin"
+	SystemRoleUser  SystemRole = "user"
+)
+
+// User represents a user in the system
+type User struct {
+	ID           uint           `gorm:"primarykey" json:"id"`
+	CreatedAt    time.Time      `json:"created_at"`
+	UpdatedAt    time.Time      `json:"updated_at"`
+	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
+	Email        string         `gorm:"uniqueIndex;not null" json:"email"`
+	PasswordHash string         `gorm:"not null" json:"-"`
+	Name         string         `gorm:"not null" json:"name"`
+	SystemRole   SystemRole     `gorm:"type:varchar(20);default:'user'" json:"system_role"`
+
+	// Relationships
+	GroupMemberships []GroupMembership `gorm:"foreignKey:UserID" json:"group_memberships,omitempty"`
+	APIKeys          []APIKey          `gorm:"foreignKey:UserID" json:"api_keys,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Add GORM data models for the core domain entities
- Auto-migrations run on server startup
- Unit tests verify model creation and constraints

## Models

| Model | Key Fields |
|-------|------------|
| **User** | email (unique), password_hash, name, system_role |
| **Group** | name, description |
| **GroupMembership** | user_id, group_id, role (admin/member) |
| **Link** | slug (unique), url, title, description, is_public, is_unread, click_count |
| **Tag** | name (unique), many-to-many with links |
| **APIKey** | key_hash, key_prefix, description, last_used_at |

## Relationships
- Users ↔ Groups via GroupMembership (many-to-many with role)
- Links → Group (many-to-one)
- Links → User (created_by)
- Links ↔ Tags (many-to-many via link_tags)
- APIKeys → User

## Test plan
- [x] `go test ./pkg/shorty/models/...` passes
- [ ] `go build ./...` compiles
- [ ] Server starts and creates tables in SQLite
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)