### PR TITLE
Add links CRUD with slug validation and group permissions

### DIFF
--- a/cmd/shorty-server/main.go
+++ b/cmd/shorty-server/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mikepea/shorty/pkg/shorty/auth"
 	"github.com/mikepea/shorty/pkg/shorty/database"
 	"github.com/mikepea/shorty/pkg/shorty/groups"
+	"github.com/mikepea/shorty/pkg/shorty/links"
 	"github.com/mikepea/shorty/pkg/shorty/models"
 )
 
@@ -59,6 +60,10 @@ func main() {
 		groupsGroup.Use(auth.AuthMiddleware())
 		groupsHandler.RegisterRoutes(groupsGroup)
 		groupsHandler.RegisterMemberRoutes(groupsGroup)
+
+		// Links routes (protected)
+		linksHandler := links.NewHandler(database.GetDB())
+		linksHandler.RegisterRoutes(api.Group("", auth.AuthMiddleware()))
 	}
 
 	// Get port from environment or use default

--- a/pkg/shorty/links/handlers.go
+++ b/pkg/shorty/links/handlers.go
@@ -1,0 +1,435 @@
+package links
+
+import (
+	"math/rand"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/gorm"
+)
+
+var slugRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// Handler handles link-related requests
+type Handler struct {
+	db *gorm.DB
+}
+
+// NewHandler creates a new links handler
+func NewHandler(db *gorm.DB) *Handler {
+	return &Handler{db: db}
+}
+
+// CreateLinkRequest represents the request to create a link
+type CreateLinkRequest struct {
+	URL         string `json:"url" binding:"required,url"`
+	Slug        string `json:"slug" binding:"omitempty,min=1,max=50"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	IsPublic    bool   `json:"is_public"`
+	IsUnread    bool   `json:"is_unread"`
+}
+
+// UpdateLinkRequest represents the request to update a link
+type UpdateLinkRequest struct {
+	URL         string `json:"url" binding:"omitempty,url"`
+	Slug        string `json:"slug" binding:"omitempty,min=1,max=50"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	IsPublic    *bool  `json:"is_public"`
+	IsUnread    *bool  `json:"is_unread"`
+}
+
+// LinkResponse represents a link in API responses
+type LinkResponse struct {
+	ID          uint   `json:"id"`
+	GroupID     uint   `json:"group_id"`
+	Slug        string `json:"slug"`
+	URL         string `json:"url"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	IsPublic    bool   `json:"is_public"`
+	IsUnread    bool   `json:"is_unread"`
+	ClickCount  uint   `json:"click_count"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+func linkToResponse(link models.Link) LinkResponse {
+	return LinkResponse{
+		ID:          link.ID,
+		GroupID:     link.GroupID,
+		Slug:        link.Slug,
+		URL:         link.URL,
+		Title:       link.Title,
+		Description: link.Description,
+		IsPublic:    link.IsPublic,
+		IsUnread:    link.IsUnread,
+		ClickCount:  link.ClickCount,
+		CreatedAt:   link.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		UpdatedAt:   link.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+}
+
+// ValidationError represents a validation error
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+// validateSlug checks if a slug is valid and available
+func (h *Handler) validateSlug(slug string, excludeID uint) error {
+	if slug == "" {
+		return nil
+	}
+
+	// Check format
+	if !slugRegex.MatchString(slug) {
+		return &ValidationError{"Slug must contain only letters, numbers, hyphens, and underscores"}
+	}
+
+	// Check reserved slugs
+	reserved := []string{"api", "health", "admin", "login", "logout", "register", "auth"}
+	for _, r := range reserved {
+		if strings.EqualFold(slug, r) {
+			return &ValidationError{"This slug is reserved"}
+		}
+	}
+
+	// Check uniqueness
+	var existing models.Link
+	query := h.db.Where("slug = ?", slug)
+	if excludeID > 0 {
+		query = query.Where("id != ?", excludeID)
+	}
+	if err := query.First(&existing).Error; err == nil {
+		return &ValidationError{"This slug is already taken"}
+	}
+
+	return nil
+}
+
+// generateRandomString creates a random string of given length
+func generateRandomString(length int, charset string) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[r.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+// generateSlug creates a unique slug
+func (h *Handler) generateSlug() string {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const length = 8
+
+	for attempts := 0; attempts < 10; attempts++ {
+		slug := generateRandomString(length, charset)
+		var existing models.Link
+		if err := h.db.Where("slug = ?", slug).First(&existing).Error; err != nil {
+			return slug
+		}
+	}
+
+	// Fallback to longer slug if short ones are exhausted
+	return generateRandomString(12, charset)
+}
+
+// checkGroupMembership verifies the user is a member of the group
+func (h *Handler) checkGroupMembership(userID, groupID uint) error {
+	var membership models.GroupMembership
+	if err := h.db.Where("user_id = ? AND group_id = ?", userID, groupID).First(&membership).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+// ListByGroup returns all links in a group
+func (h *Handler) ListByGroup(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, uint(groupID)); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
+		return
+	}
+
+	var links []models.Link
+	query := h.db.Where("group_id = ?", groupID).Order("created_at DESC")
+
+	// Optional filters
+	if isUnread := c.Query("is_unread"); isUnread != "" {
+		query = query.Where("is_unread = ?", isUnread == "true")
+	}
+	if isPublic := c.Query("is_public"); isPublic != "" {
+		query = query.Where("is_public = ?", isPublic == "true")
+	}
+
+	if err := query.Find(&links).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch links"})
+		return
+	}
+
+	responses := make([]LinkResponse, len(links))
+	for i, link := range links {
+		responses[i] = linkToResponse(link)
+	}
+
+	c.JSON(http.StatusOK, responses)
+}
+
+// Create creates a new link in a group
+func (h *Handler) Create(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, uint(groupID)); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
+		return
+	}
+
+	var req CreateLinkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Handle slug
+	slug := req.Slug
+	if slug == "" {
+		slug = h.generateSlug()
+	} else {
+		if err := h.validateSlug(slug, 0); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	link := models.Link{
+		GroupID:     uint(groupID),
+		CreatedByID: userID,
+		Slug:        slug,
+		URL:         req.URL,
+		Title:       req.Title,
+		Description: req.Description,
+		IsPublic:    req.IsPublic,
+		IsUnread:    req.IsUnread,
+	}
+
+	if err := h.db.Create(&link).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create link"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, linkToResponse(link))
+}
+
+// GetBySlug returns a link by its slug
+func (h *Handler) GetBySlug(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+
+	var link models.Link
+	if err := h.db.Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check if user has access (public or member of group)
+	if !link.IsPublic {
+		if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, linkToResponse(link))
+}
+
+// Update updates a link
+func (h *Handler) Update(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+
+	var link models.Link
+	if err := h.db.Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	var req UpdateLinkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Validate new slug if provided
+	if req.Slug != "" && req.Slug != link.Slug {
+		if err := h.validateSlug(req.Slug, link.ID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		link.Slug = req.Slug
+	}
+
+	// Update fields
+	if req.URL != "" {
+		link.URL = req.URL
+	}
+	if req.Title != "" {
+		link.Title = req.Title
+	}
+	if req.Description != "" {
+		link.Description = req.Description
+	}
+	if req.IsPublic != nil {
+		link.IsPublic = *req.IsPublic
+	}
+	if req.IsUnread != nil {
+		link.IsUnread = *req.IsUnread
+	}
+
+	if err := h.db.Save(&link).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update link"})
+		return
+	}
+
+	c.JSON(http.StatusOK, linkToResponse(link))
+}
+
+// Delete deletes a link
+func (h *Handler) Delete(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+
+	var link models.Link
+	if err := h.db.Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	if err := h.db.Delete(&link).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete link"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Link deleted"})
+}
+
+// Search searches links across all user's groups
+func (h *Handler) Search(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+
+	// Get user's group IDs
+	var memberships []models.GroupMembership
+	if err := h.db.Where("user_id = ?", userID).Find(&memberships).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch groups"})
+		return
+	}
+
+	groupIDs := make([]uint, len(memberships))
+	for i, m := range memberships {
+		groupIDs[i] = m.GroupID
+	}
+
+	if len(groupIDs) == 0 {
+		c.JSON(http.StatusOK, []LinkResponse{})
+		return
+	}
+
+	query := h.db.Where("group_id IN ?", groupIDs).Order("created_at DESC")
+
+	// Search term
+	if q := c.Query("q"); q != "" {
+		searchTerm := "%" + q + "%"
+		query = query.Where("title LIKE ? OR description LIKE ? OR url LIKE ?", searchTerm, searchTerm, searchTerm)
+	}
+
+	// Filters
+	if isUnread := c.Query("is_unread"); isUnread != "" {
+		query = query.Where("is_unread = ?", isUnread == "true")
+	}
+	if isPublic := c.Query("is_public"); isPublic != "" {
+		query = query.Where("is_public = ?", isPublic == "true")
+	}
+	if groupID := c.Query("group_id"); groupID != "" {
+		query = query.Where("group_id = ?", groupID)
+	}
+
+	// Pagination
+	limit := 50
+	if l := c.Query("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 100 {
+			limit = parsed
+		}
+	}
+	query = query.Limit(limit)
+
+	offset := 0
+	if o := c.Query("offset"); o != "" {
+		if parsed, err := strconv.Atoi(o); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+	query = query.Offset(offset)
+
+	var links []models.Link
+	if err := query.Find(&links).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search links"})
+		return
+	}
+
+	responses := make([]LinkResponse, len(links))
+	for i, link := range links {
+		responses[i] = linkToResponse(link)
+	}
+
+	c.JSON(http.StatusOK, responses)
+}
+
+// RegisterRoutes registers link routes
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+	// Group-scoped routes
+	rg.GET("/groups/:groupId/links", h.ListByGroup)
+	rg.POST("/groups/:groupId/links", h.Create)
+
+	// Slug-based routes
+	rg.GET("/links/:slug", h.GetBySlug)
+	rg.PUT("/links/:slug", h.Update)
+	rg.DELETE("/links/:slug", h.Delete)
+
+	// Search across all groups
+	rg.GET("/links", h.Search)
+}

--- a/pkg/shorty/links/links_test.go
+++ b/pkg/shorty/links/links_test.go
@@ -1,0 +1,427 @@
+package links
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+	models.AutoMigrate(db)
+	return db
+}
+
+func createTestUser(t *testing.T, db *gorm.DB, email string) models.User {
+	hash, _ := auth.HashPassword("password123")
+	user := models.User{
+		Email:        email,
+		PasswordHash: hash,
+		Name:         "Test User",
+		SystemRole:   models.SystemRoleUser,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+	return user
+}
+
+func createTestGroup(t *testing.T, db *gorm.DB, name string, userID uint) models.Group {
+	group := models.Group{Name: name}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("Failed to create test group: %v", err)
+	}
+	membership := models.GroupMembership{
+		UserID:  userID,
+		GroupID: group.ID,
+		Role:    models.GroupRoleAdmin,
+	}
+	if err := db.Create(&membership).Error; err != nil {
+		t.Fatalf("Failed to create test membership: %v", err)
+	}
+	return group
+}
+
+func setupTestRouter(db *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	handler := NewHandler(db)
+
+	api := r.Group("/api")
+	api.Use(auth.AuthMiddleware())
+	handler.RegisterRoutes(api)
+
+	return r
+}
+
+func getAuthHeader(user models.User) string {
+	token, _ := auth.GenerateToken(user.ID, user.Email, string(user.SystemRole))
+	return "Bearer " + token
+}
+
+func TestCreateLink(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	body := CreateLinkRequest{
+		URL:         "https://example.com",
+		Slug:        "my-link",
+		Title:       "Example",
+		Description: "An example link",
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", "/api/groups/1/links", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var response LinkResponse
+	json.Unmarshal(resp.Body.Bytes(), &response)
+
+	if response.Slug != "my-link" {
+		t.Errorf("Expected slug 'my-link', got %s", response.Slug)
+	}
+	if response.GroupID != group.ID {
+		t.Errorf("Expected group ID %d, got %d", group.ID, response.GroupID)
+	}
+}
+
+func TestCreateLinkAutoSlug(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	createTestGroup(t, db, "Test Group", user.ID)
+
+	body := CreateLinkRequest{
+		URL:   "https://example.com",
+		Title: "Example",
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", "/api/groups/1/links", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var response LinkResponse
+	json.Unmarshal(resp.Body.Bytes(), &response)
+
+	if response.Slug == "" {
+		t.Error("Expected auto-generated slug")
+	}
+	if len(response.Slug) != 8 {
+		t.Errorf("Expected 8-char slug, got %d chars", len(response.Slug))
+	}
+}
+
+func TestCreateLinkDuplicateSlug(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	createTestGroup(t, db, "Test Group", user.ID)
+
+	// Create first link
+	link := models.Link{
+		GroupID:     1,
+		CreatedByID: user.ID,
+		Slug:        "existing-slug",
+		URL:         "https://example.com",
+	}
+	db.Create(&link)
+
+	// Try to create second link with same slug
+	body := CreateLinkRequest{
+		URL:  "https://another.com",
+		Slug: "existing-slug",
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", "/api/groups/1/links", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", resp.Code)
+	}
+}
+
+func TestCreateLinkReservedSlug(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	createTestGroup(t, db, "Test Group", user.ID)
+
+	body := CreateLinkRequest{
+		URL:  "https://example.com",
+		Slug: "api",
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", "/api/groups/1/links", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", resp.Code)
+	}
+}
+
+func TestListLinks(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	// Create some links
+	for i := 0; i < 3; i++ {
+		db.Create(&models.Link{
+			GroupID:     group.ID,
+			CreatedByID: user.ID,
+			Slug:        generateRandomString(8, "abcdef"),
+			URL:         "https://example.com",
+		})
+	}
+
+	req, _ := http.NewRequest("GET", "/api/groups/1/links", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var links []LinkResponse
+	json.Unmarshal(resp.Body.Bytes(), &links)
+
+	if len(links) != 3 {
+		t.Errorf("Expected 3 links, got %d", len(links))
+	}
+}
+
+func TestGetLinkBySlug(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	link := models.Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "test-link",
+		URL:         "https://example.com",
+		Title:       "Test Link",
+	}
+	db.Create(&link)
+
+	req, _ := http.NewRequest("GET", "/api/links/test-link", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var response LinkResponse
+	json.Unmarshal(resp.Body.Bytes(), &response)
+
+	if response.Title != "Test Link" {
+		t.Errorf("Expected title 'Test Link', got %s", response.Title)
+	}
+}
+
+func TestGetPrivateLinkNotMember(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	owner := createTestUser(t, db, "owner@example.com")
+	other := createTestUser(t, db, "other@example.com")
+	group := createTestGroup(t, db, "Test Group", owner.ID)
+
+	link := models.Link{
+		GroupID:     group.ID,
+		CreatedByID: owner.ID,
+		Slug:        "private-link",
+		URL:         "https://example.com",
+		IsPublic:    false,
+	}
+	db.Create(&link)
+
+	req, _ := http.NewRequest("GET", "/api/links/private-link", nil)
+	req.Header.Set("Authorization", getAuthHeader(other))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.Code)
+	}
+}
+
+func TestGetPublicLinkNotMember(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	owner := createTestUser(t, db, "owner@example.com")
+	other := createTestUser(t, db, "other@example.com")
+	group := createTestGroup(t, db, "Test Group", owner.ID)
+
+	link := models.Link{
+		GroupID:     group.ID,
+		CreatedByID: owner.ID,
+		Slug:        "public-link",
+		URL:         "https://example.com",
+		IsPublic:    true,
+	}
+	db.Create(&link)
+
+	req, _ := http.NewRequest("GET", "/api/links/public-link", nil)
+	req.Header.Set("Authorization", getAuthHeader(other))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.Code)
+	}
+}
+
+func TestUpdateLink(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	link := models.Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "test-link",
+		URL:         "https://example.com",
+		Title:       "Old Title",
+	}
+	db.Create(&link)
+
+	body := UpdateLinkRequest{
+		Title: "New Title",
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("PUT", "/api/links/test-link", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var response LinkResponse
+	json.Unmarshal(resp.Body.Bytes(), &response)
+
+	if response.Title != "New Title" {
+		t.Errorf("Expected title 'New Title', got %s", response.Title)
+	}
+}
+
+func TestDeleteLink(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	link := models.Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "test-link",
+		URL:         "https://example.com",
+	}
+	db.Create(&link)
+
+	req, _ := http.NewRequest("DELETE", "/api/links/test-link", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestSearchLinks(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	// Create links with different titles
+	db.Create(&models.Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "link1",
+		URL:         "https://example.com",
+		Title:       "Golang Tutorial",
+	})
+	db.Create(&models.Link{
+		GroupID:     group.ID,
+		CreatedByID: user.ID,
+		Slug:        "link2",
+		URL:         "https://example.com",
+		Title:       "Python Guide",
+	})
+
+	req, _ := http.NewRequest("GET", "/api/links?q=Golang", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var links []LinkResponse
+	json.Unmarshal(resp.Body.Bytes(), &links)
+
+	if len(links) != 1 {
+		t.Errorf("Expected 1 link, got %d", len(links))
+	}
+	if links[0].Title != "Golang Tutorial" {
+		t.Errorf("Expected 'Golang Tutorial', got %s", links[0].Title)
+	}
+}


### PR DESCRIPTION
## Summary
- Full CRUD for links within groups
- Custom slugs with validation (or auto-generated)
- Group-based access control for private links
- Search across all user's groups with filtering

## Endpoints

| Method | Path | Description | Auth |
|--------|------|-------------|------|
| GET | `/api/groups/:groupId/links` | List links in group | Yes (member) |
| POST | `/api/groups/:groupId/links` | Create link in group | Yes (member) |
| GET | `/api/links/:slug` | Get link by slug | Yes (member or public) |
| PUT | `/api/links/:slug` | Update link | Yes (member) |
| DELETE | `/api/links/:slug` | Delete link | Yes (member) |
| GET | `/api/links` | Search all links | Yes |

## Query Parameters (Search)
- `q`: Search term (matches title, description, URL)
- `is_unread`: Filter by unread status
- `is_public`: Filter by public/private
- `group_id`: Filter by specific group
- `limit`: Results per page (default 50, max 100)
- `offset`: Pagination offset

## Slug Features
- **Custom slugs**: User-defined, validated for format and uniqueness
- **Auto-generated**: 8-character alphanumeric if not provided
- **Reserved words**: `api`, `health`, `admin`, `login`, `logout`, `register`, `auth`
- **Global uniqueness**: Slugs are unique across all groups

## Test plan
- [x] `go test ./pkg/shorty/links/...` passes (11 tests)
- [x] `go test ./...` all tests pass
- [ ] `go build ./...` compiles
- [ ] Manual test: create link → update → search → delete
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)