### PR TITLE
Add tag management and link-tag associations

### DIFF
--- a/cmd/shorty-server/main.go
+++ b/cmd/shorty-server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mikepea/shorty/pkg/shorty/groups"
 	"github.com/mikepea/shorty/pkg/shorty/links"
 	"github.com/mikepea/shorty/pkg/shorty/models"
+	"github.com/mikepea/shorty/pkg/shorty/tags"
 )
 
 func main() {
@@ -64,6 +65,10 @@ func main() {
 		// Links routes (protected)
 		linksHandler := links.NewHandler(database.GetDB())
 		linksHandler.RegisterRoutes(api.Group("", auth.AuthMiddleware()))
+
+		// Tags routes (protected)
+		tagsHandler := tags.NewHandler(database.GetDB())
+		tagsHandler.RegisterRoutes(api.Group("", auth.AuthMiddleware()))
 	}
 
 	// Get port from environment or use default

--- a/pkg/shorty/links/handlers.go
+++ b/pkg/shorty/links/handlers.go
@@ -387,6 +387,11 @@ func (h *Handler) Search(c *gin.Context) {
 	if groupID := c.Query("group_id"); groupID != "" {
 		query = query.Where("group_id = ?", groupID)
 	}
+	if tag := c.Query("tag"); tag != "" {
+		query = query.Joins("JOIN link_tags ON link_tags.link_id = links.id").
+			Joins("JOIN tags ON tags.id = link_tags.tag_id").
+			Where("tags.name = ?", tag)
+	}
 
 	// Pagination
 	limit := 50

--- a/pkg/shorty/tags/handlers.go
+++ b/pkg/shorty/tags/handlers.go
@@ -1,0 +1,333 @@
+package tags
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/gorm"
+)
+
+// Handler handles tag-related requests
+type Handler struct {
+	db *gorm.DB
+}
+
+// NewHandler creates a new tags handler
+func NewHandler(db *gorm.DB) *Handler {
+	return &Handler{db: db}
+}
+
+// TagResponse represents a tag in API responses
+type TagResponse struct {
+	ID        uint   `json:"id"`
+	Name      string `json:"name"`
+	LinkCount int    `json:"link_count,omitempty"`
+}
+
+// SetTagsRequest represents the request to set tags on a link
+type SetTagsRequest struct {
+	Tags []string `json:"tags" binding:"required"`
+}
+
+// getUserGroupIDs returns all group IDs the user is a member of
+func (h *Handler) getUserGroupIDs(userID uint) ([]uint, error) {
+	var memberships []models.GroupMembership
+	if err := h.db.Where("user_id = ?", userID).Find(&memberships).Error; err != nil {
+		return nil, err
+	}
+
+	groupIDs := make([]uint, len(memberships))
+	for i, m := range memberships {
+		groupIDs[i] = m.GroupID
+	}
+	return groupIDs, nil
+}
+
+// checkGroupMembership verifies the user is a member of the group
+func (h *Handler) checkGroupMembership(userID, groupID uint) error {
+	var membership models.GroupMembership
+	if err := h.db.Where("user_id = ? AND group_id = ?", userID, groupID).First(&membership).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+// List returns all tags used across the user's groups
+func (h *Handler) List(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+
+	groupIDs, err := h.getUserGroupIDs(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch groups"})
+		return
+	}
+
+	if len(groupIDs) == 0 {
+		c.JSON(http.StatusOK, []TagResponse{})
+		return
+	}
+
+	// Get tags with link counts for user's groups
+	type tagWithCount struct {
+		ID        uint
+		Name      string
+		LinkCount int
+	}
+
+	var results []tagWithCount
+	err = h.db.Table("tags").
+		Select("tags.id, tags.name, COUNT(DISTINCT links.id) as link_count").
+		Joins("INNER JOIN link_tags ON tags.id = link_tags.tag_id").
+		Joins("INNER JOIN links ON link_tags.link_id = links.id AND links.group_id IN ? AND links.deleted_at IS NULL", groupIDs).
+		Where("tags.deleted_at IS NULL").
+		Group("tags.id").
+		Order("link_count DESC").
+		Find(&results).Error
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch tags"})
+		return
+	}
+
+	tags := make([]TagResponse, len(results))
+	for i, r := range results {
+		tags[i] = TagResponse{
+			ID:        r.ID,
+			Name:      r.Name,
+			LinkCount: r.LinkCount,
+		}
+	}
+
+	c.JSON(http.StatusOK, tags)
+}
+
+// ListByGroup returns all tags used in a specific group
+func (h *Handler) ListByGroup(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	groupID, err := strconv.ParseUint(c.Param("groupId"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, uint(groupID)); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
+		return
+	}
+
+	type tagWithCount struct {
+		ID        uint
+		Name      string
+		LinkCount int
+	}
+
+	var results []tagWithCount
+	err = h.db.Table("tags").
+		Select("tags.id, tags.name, COUNT(DISTINCT links.id) as link_count").
+		Joins("INNER JOIN link_tags ON tags.id = link_tags.tag_id").
+		Joins("INNER JOIN links ON link_tags.link_id = links.id AND links.group_id = ? AND links.deleted_at IS NULL", groupID).
+		Where("tags.deleted_at IS NULL").
+		Group("tags.id").
+		Order("link_count DESC").
+		Find(&results).Error
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch tags"})
+		return
+	}
+
+	tags := make([]TagResponse, len(results))
+	for i, r := range results {
+		tags[i] = TagResponse{
+			ID:        r.ID,
+			Name:      r.Name,
+			LinkCount: r.LinkCount,
+		}
+	}
+
+	c.JSON(http.StatusOK, tags)
+}
+
+// GetLinkTags returns tags for a specific link
+func (h *Handler) GetLinkTags(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+
+	var link models.Link
+	if err := h.db.Preload("Tags").Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check access
+	if !link.IsPublic {
+		if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+			return
+		}
+	}
+
+	tags := make([]TagResponse, len(link.Tags))
+	for i, t := range link.Tags {
+		tags[i] = TagResponse{
+			ID:   t.ID,
+			Name: t.Name,
+		}
+	}
+
+	c.JSON(http.StatusOK, tags)
+}
+
+// SetLinkTags sets the tags for a link (replaces existing tags)
+func (h *Handler) SetLinkTags(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+
+	var link models.Link
+	if err := h.db.Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	var req SetTagsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Get or create tags
+	var tags []models.Tag
+	for _, tagName := range req.Tags {
+		if tagName == "" {
+			continue
+		}
+
+		var tag models.Tag
+		// Try to find existing tag
+		if err := h.db.Where("name = ?", tagName).First(&tag).Error; err != nil {
+			// Create new tag
+			tag = models.Tag{Name: tagName}
+			if err := h.db.Create(&tag).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create tag"})
+				return
+			}
+		}
+		tags = append(tags, tag)
+	}
+
+	// Replace link's tags
+	if err := h.db.Model(&link).Association("Tags").Replace(tags); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update tags"})
+		return
+	}
+
+	// Return updated tags
+	tagResponses := make([]TagResponse, len(tags))
+	for i, t := range tags {
+		tagResponses[i] = TagResponse{
+			ID:   t.ID,
+			Name: t.Name,
+		}
+	}
+
+	c.JSON(http.StatusOK, tagResponses)
+}
+
+// AddLinkTag adds a single tag to a link
+func (h *Handler) AddLinkTag(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+	tagName := c.Param("tag")
+
+	var link models.Link
+	if err := h.db.Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Get or create tag
+	var tag models.Tag
+	if err := h.db.Where("name = ?", tagName).First(&tag).Error; err != nil {
+		tag = models.Tag{Name: tagName}
+		if err := h.db.Create(&tag).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create tag"})
+			return
+		}
+	}
+
+	// Add tag to link
+	if err := h.db.Model(&link).Association("Tags").Append(&tag); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to add tag"})
+		return
+	}
+
+	c.JSON(http.StatusOK, TagResponse{
+		ID:   tag.ID,
+		Name: tag.Name,
+	})
+}
+
+// RemoveLinkTag removes a tag from a link
+func (h *Handler) RemoveLinkTag(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+	tagName := c.Param("tag")
+
+	var link models.Link
+	if err := h.db.Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check membership
+	if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Find tag
+	var tag models.Tag
+	if err := h.db.Where("name = ?", tagName).First(&tag).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Tag not found"})
+		return
+	}
+
+	// Remove tag from link
+	if err := h.db.Model(&link).Association("Tags").Delete(&tag); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove tag"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Tag removed"})
+}
+
+// RegisterRoutes registers tag routes
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+	// List all tags across user's groups
+	rg.GET("/tags", h.List)
+
+	// List tags in a specific group
+	rg.GET("/groups/:groupId/tags", h.ListByGroup)
+
+	// Link tag operations
+	rg.GET("/links/:slug/tags", h.GetLinkTags)
+	rg.PUT("/links/:slug/tags", h.SetLinkTags)
+	rg.POST("/links/:slug/tags/:tag", h.AddLinkTag)
+	rg.DELETE("/links/:slug/tags/:tag", h.RemoveLinkTag)
+}

--- a/pkg/shorty/tags/tags_test.go
+++ b/pkg/shorty/tags/tags_test.go
@@ -1,0 +1,329 @@
+package tags
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+	models.AutoMigrate(db)
+	return db
+}
+
+func createTestUser(t *testing.T, db *gorm.DB, email string) models.User {
+	hash, _ := auth.HashPassword("password123")
+	user := models.User{
+		Email:        email,
+		PasswordHash: hash,
+		Name:         "Test User",
+		SystemRole:   models.SystemRoleUser,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+	return user
+}
+
+func createTestGroup(t *testing.T, db *gorm.DB, name string, userID uint) models.Group {
+	group := models.Group{Name: name}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("Failed to create test group: %v", err)
+	}
+	membership := models.GroupMembership{
+		UserID:  userID,
+		GroupID: group.ID,
+		Role:    models.GroupRoleAdmin,
+	}
+	if err := db.Create(&membership).Error; err != nil {
+		t.Fatalf("Failed to create test membership: %v", err)
+	}
+	return group
+}
+
+func createTestLink(t *testing.T, db *gorm.DB, groupID, userID uint, slug string) models.Link {
+	link := models.Link{
+		GroupID:     groupID,
+		CreatedByID: userID,
+		Slug:        slug,
+		URL:         "https://example.com",
+		Title:       "Test Link",
+	}
+	if err := db.Create(&link).Error; err != nil {
+		t.Fatalf("Failed to create test link: %v", err)
+	}
+	return link
+}
+
+func setupTestRouter(db *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	handler := NewHandler(db)
+
+	api := r.Group("/api")
+	api.Use(auth.AuthMiddleware())
+	handler.RegisterRoutes(api)
+
+	return r
+}
+
+func getAuthHeader(user models.User) string {
+	token, _ := auth.GenerateToken(user.ID, user.Email, string(user.SystemRole))
+	return "Bearer " + token
+}
+
+func TestListTags(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+	link := createTestLink(t, db, group.ID, user.ID, "test-link")
+
+	// Create tags and associate with link
+	tag1 := models.Tag{Name: "golang"}
+	tag2 := models.Tag{Name: "programming"}
+	db.Create(&tag1)
+	db.Create(&tag2)
+	db.Model(&link).Association("Tags").Append(&tag1, &tag2)
+
+	req, _ := http.NewRequest("GET", "/api/tags", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var tags []TagResponse
+	json.Unmarshal(resp.Body.Bytes(), &tags)
+
+	if len(tags) != 2 {
+		t.Errorf("Expected 2 tags, got %d", len(tags))
+	}
+}
+
+func TestListTagsByGroup(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group1 := createTestGroup(t, db, "Group 1", user.ID)
+	group2 := createTestGroup(t, db, "Group 2", user.ID)
+
+	link1 := createTestLink(t, db, group1.ID, user.ID, "link1")
+	link2 := createTestLink(t, db, group2.ID, user.ID, "link2")
+
+	tag1 := models.Tag{Name: "group1-tag"}
+	tag2 := models.Tag{Name: "group2-tag"}
+	db.Create(&tag1)
+	db.Create(&tag2)
+	db.Model(&link1).Association("Tags").Append(&tag1)
+	db.Model(&link2).Association("Tags").Append(&tag2)
+
+	req, _ := http.NewRequest("GET", "/api/groups/1/tags", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var tags []TagResponse
+	json.Unmarshal(resp.Body.Bytes(), &tags)
+
+	if len(tags) != 1 {
+		t.Errorf("Expected 1 tag, got %d", len(tags))
+	}
+	if len(tags) > 0 && tags[0].Name != "group1-tag" {
+		t.Errorf("Expected 'group1-tag', got %s", tags[0].Name)
+	}
+}
+
+func TestGetLinkTags(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+	link := createTestLink(t, db, group.ID, user.ID, "test-link")
+
+	tag := models.Tag{Name: "test-tag"}
+	db.Create(&tag)
+	db.Model(&link).Association("Tags").Append(&tag)
+
+	req, _ := http.NewRequest("GET", "/api/links/test-link/tags", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var tags []TagResponse
+	json.Unmarshal(resp.Body.Bytes(), &tags)
+
+	if len(tags) != 1 {
+		t.Errorf("Expected 1 tag, got %d", len(tags))
+	}
+}
+
+func TestSetLinkTags(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+	createTestLink(t, db, group.ID, user.ID, "test-link")
+
+	body := SetTagsRequest{
+		Tags: []string{"tag1", "tag2", "tag3"},
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("PUT", "/api/links/test-link/tags", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var tags []TagResponse
+	json.Unmarshal(resp.Body.Bytes(), &tags)
+
+	if len(tags) != 3 {
+		t.Errorf("Expected 3 tags, got %d", len(tags))
+	}
+}
+
+func TestSetLinkTagsReplacesExisting(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+	link := createTestLink(t, db, group.ID, user.ID, "test-link")
+
+	// Add initial tag
+	oldTag := models.Tag{Name: "old-tag"}
+	db.Create(&oldTag)
+	db.Model(&link).Association("Tags").Append(&oldTag)
+
+	// Replace with new tags
+	body := SetTagsRequest{
+		Tags: []string{"new-tag"},
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("PUT", "/api/links/test-link/tags", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var tags []TagResponse
+	json.Unmarshal(resp.Body.Bytes(), &tags)
+
+	if len(tags) != 1 {
+		t.Errorf("Expected 1 tag, got %d", len(tags))
+	}
+	if len(tags) > 0 && tags[0].Name != "new-tag" {
+		t.Errorf("Expected 'new-tag', got %s", tags[0].Name)
+	}
+}
+
+func TestAddLinkTag(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+	createTestLink(t, db, group.ID, user.ID, "test-link")
+
+	req, _ := http.NewRequest("POST", "/api/links/test-link/tags/new-tag", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var tag TagResponse
+	json.Unmarshal(resp.Body.Bytes(), &tag)
+
+	if tag.Name != "new-tag" {
+		t.Errorf("Expected 'new-tag', got %s", tag.Name)
+	}
+}
+
+func TestRemoveLinkTag(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+	link := createTestLink(t, db, group.ID, user.ID, "test-link")
+
+	tag := models.Tag{Name: "remove-me"}
+	db.Create(&tag)
+	db.Model(&link).Association("Tags").Append(&tag)
+
+	req, _ := http.NewRequest("DELETE", "/api/links/test-link/tags/remove-me", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Verify tag was removed
+	var updatedLink models.Link
+	db.Preload("Tags").First(&updatedLink, link.ID)
+	if len(updatedLink.Tags) != 0 {
+		t.Errorf("Expected 0 tags, got %d", len(updatedLink.Tags))
+	}
+}
+
+func TestTagAccessControl(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	owner := createTestUser(t, db, "owner@example.com")
+	other := createTestUser(t, db, "other@example.com")
+	group := createTestGroup(t, db, "Test Group", owner.ID)
+	createTestLink(t, db, group.ID, owner.ID, "test-link")
+
+	// Other user should not be able to modify tags
+	req, _ := http.NewRequest("POST", "/api/links/test-link/tags/hack", nil)
+	req.Header.Set("Authorization", getAuthHeader(other))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Tag management across groups
- Link-tag associations (add/remove/set)
- Tag filtering in link search
- Tags include link counts

## Endpoints

| Method | Path | Description | Auth |
|--------|------|-------------|------|
| GET | `/api/tags` | List all tags (user's groups) | Yes |
| GET | `/api/groups/:groupId/tags` | List tags in group | Yes (member) |
| GET | `/api/links/:slug/tags` | Get link's tags | Yes |
| PUT | `/api/links/:slug/tags` | Set link's tags | Yes (member) |
| POST | `/api/links/:slug/tags/:tag` | Add tag to link | Yes (member) |
| DELETE | `/api/links/:slug/tags/:tag` | Remove tag from link | Yes (member) |

## Search Integration
- `GET /api/links?tag=golang` - filter by tag name

## Features
- **Tag counts**: Each tag response includes count of associated links
- **Auto-create**: Tags are created automatically when first used
- **Replace mode**: `PUT` replaces all tags on a link
- **Scoped counts**: Tag counts respect group membership (only count links user can see)

## Test plan
- [x] `go test ./pkg/shorty/tags/...` passes (8 tests)
- [x] `go test ./...` all tests pass
- [ ] `go build ./...` compiles
- [ ] Manual test: create link → add tags → search by tag → remove tag
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)