### PR TITLE
Add API keys with CRUD and combined auth middleware

### DIFF
--- a/pkg/shorty/apikeys/apikeys_test.go
+++ b/pkg/shorty/apikeys/apikeys_test.go
@@ -1,0 +1,343 @@
+package apikeys
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+	models.AutoMigrate(db)
+	return db
+}
+
+func createTestUser(t *testing.T, db *gorm.DB, email string) models.User {
+	hash, _ := auth.HashPassword("password123")
+	user := models.User{
+		Email:        email,
+		PasswordHash: hash,
+		Name:         "Test User",
+		SystemRole:   models.SystemRoleUser,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+	return user
+}
+
+func setupTestRouter(db *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	handler := NewHandler(db)
+
+	api := r.Group("/api")
+	api.Use(auth.AuthMiddleware())
+	handler.RegisterRoutes(api)
+
+	return r
+}
+
+func getAuthHeader(user models.User) string {
+	token, _ := auth.GenerateToken(user.ID, user.Email, string(user.SystemRole))
+	return "Bearer " + token
+}
+
+func TestCreateAPIKey(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+
+	body := CreateAPIKeyRequest{
+		Description: "Test API Key",
+	}
+	jsonBody, _ := json.Marshal(body)
+
+	req, _ := http.NewRequest("POST", "/api/api-keys", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var response CreateAPIKeyResponse
+	json.Unmarshal(resp.Body.Bytes(), &response)
+
+	if response.Key == "" {
+		t.Error("Expected API key to be returned")
+	}
+
+	if len(response.Key) != KeyLength*2 { // hex encoding doubles the length
+		t.Errorf("Expected key length %d, got %d", KeyLength*2, len(response.Key))
+	}
+
+	if response.KeyPrefix != response.Key[:KeyPrefixLength] {
+		t.Error("Key prefix should match the start of the key")
+	}
+
+	if response.Description != "Test API Key" {
+		t.Errorf("Expected description 'Test API Key', got '%s'", response.Description)
+	}
+}
+
+func TestCreateAPIKeyWithoutDescription(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+
+	req, _ := http.NewRequest("POST", "/api/api-keys", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestListAPIKeys(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+
+	// Create a couple API keys directly in the database
+	keys := []models.APIKey{
+		{UserID: user.ID, KeyHash: "hash1", KeyPrefix: "key1abcd", Description: "Key 1", CreatedByID: user.ID},
+		{UserID: user.ID, KeyHash: "hash2", KeyPrefix: "key2efgh", Description: "Key 2", CreatedByID: user.ID},
+	}
+	for _, key := range keys {
+		db.Create(&key)
+	}
+
+	req, _ := http.NewRequest("GET", "/api/api-keys", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var response []APIKeyResponse
+	json.Unmarshal(resp.Body.Bytes(), &response)
+
+	if len(response) != 2 {
+		t.Errorf("Expected 2 API keys, got %d", len(response))
+	}
+}
+
+func TestListAPIKeysOnlyShowsOwnKeys(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user1 := createTestUser(t, db, "user1@example.com")
+	user2 := createTestUser(t, db, "user2@example.com")
+
+	// Create keys for both users
+	db.Create(&models.APIKey{UserID: user1.ID, KeyHash: "hash1", KeyPrefix: "key1abcd", CreatedByID: user1.ID})
+	db.Create(&models.APIKey{UserID: user2.ID, KeyHash: "hash2", KeyPrefix: "key2efgh", CreatedByID: user2.ID})
+
+	// User1 should only see their own key
+	req, _ := http.NewRequest("GET", "/api/api-keys", nil)
+	req.Header.Set("Authorization", getAuthHeader(user1))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	var response []APIKeyResponse
+	json.Unmarshal(resp.Body.Bytes(), &response)
+
+	if len(response) != 1 {
+		t.Errorf("Expected 1 API key, got %d", len(response))
+	}
+
+	if response[0].KeyPrefix != "key1abcd" {
+		t.Error("Should only see own API key")
+	}
+}
+
+func TestDeleteAPIKey(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+
+	// Create an API key
+	apiKey := models.APIKey{UserID: user.ID, KeyHash: "hash1", KeyPrefix: "key1abcd", CreatedByID: user.ID}
+	db.Create(&apiKey)
+
+	req, _ := http.NewRequest("DELETE", "/api/api-keys/1", nil)
+	req.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Verify it's deleted
+	var count int64
+	db.Model(&models.APIKey{}).Where("id = ?", apiKey.ID).Count(&count)
+	if count != 0 {
+		t.Error("API key should be deleted")
+	}
+}
+
+func TestDeleteAPIKeyNotOwned(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user1 := createTestUser(t, db, "user1@example.com")
+	user2 := createTestUser(t, db, "user2@example.com")
+
+	// Create an API key for user2
+	apiKey := models.APIKey{UserID: user2.ID, KeyHash: "hash1", KeyPrefix: "key1abcd", CreatedByID: user2.ID}
+	db.Create(&apiKey)
+
+	// User1 tries to delete it
+	req, _ := http.NewRequest("DELETE", "/api/api-keys/1", nil)
+	req.Header.Set("Authorization", getAuthHeader(user1))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.Code)
+	}
+}
+
+func TestValidateAPIKey(t *testing.T) {
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "test@example.com")
+
+	// Create an API key with known hash
+	key := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	apiKey := models.APIKey{
+		UserID:      user.ID,
+		KeyHash:     hashAPIKey(key),
+		KeyPrefix:   key[:KeyPrefixLength],
+		CreatedByID: user.ID,
+	}
+	db.Create(&apiKey)
+
+	// Validate with correct key
+	result, err := ValidateAPIKey(db, key)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if result.ID != apiKey.ID {
+		t.Error("Expected to find the API key")
+	}
+
+	// Validate with wrong key
+	_, err = ValidateAPIKey(db, "wrongkey")
+	if err == nil {
+		t.Error("Expected error for invalid key")
+	}
+}
+
+func TestCombinedAuthMiddleware(t *testing.T) {
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "test@example.com")
+
+	// Create an API key
+	key := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	apiKey := models.APIKey{
+		UserID:      user.ID,
+		KeyHash:     hashAPIKey(key),
+		KeyPrefix:   key[:KeyPrefixLength],
+		CreatedByID: user.ID,
+	}
+	db.Create(&apiKey)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(CombinedAuthMiddleware(db))
+	r.GET("/test", func(c *gin.Context) {
+		userID, _ := c.Get("user_id")
+		c.JSON(http.StatusOK, gin.H{"user_id": userID})
+	})
+
+	// Test with valid API key
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	resp := httptest.NewRecorder()
+
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Verify user ID is set
+	var response map[string]interface{}
+	json.Unmarshal(resp.Body.Bytes(), &response)
+	if uint(response["user_id"].(float64)) != user.ID {
+		t.Error("User ID should be set in context")
+	}
+}
+
+func TestCombinedAuthMiddlewareInvalidKey(t *testing.T) {
+	db := setupTestDB(t)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(CombinedAuthMiddleware(db))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer invalidkey")
+	resp := httptest.NewRecorder()
+
+	r.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status 401, got %d", resp.Code)
+	}
+}
+
+func TestUpdateLastUsed(t *testing.T) {
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "test@example.com")
+
+	// Create an API key without last_used
+	apiKey := models.APIKey{
+		UserID:      user.ID,
+		KeyHash:     "hash1",
+		KeyPrefix:   "key1abcd",
+		CreatedByID: user.ID,
+	}
+	db.Create(&apiKey)
+
+	// Update last used
+	UpdateLastUsed(db, apiKey.ID)
+
+	// Give it a moment for the update
+	time.Sleep(10 * time.Millisecond)
+
+	// Check it was updated
+	var updated models.APIKey
+	db.First(&updated, apiKey.ID)
+
+	if updated.LastUsedAt == nil {
+		t.Error("LastUsedAt should be set")
+	}
+}

--- a/pkg/shorty/apikeys/handlers.go
+++ b/pkg/shorty/apikeys/handlers.go
@@ -1,0 +1,254 @@
+package apikeys
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/gorm"
+)
+
+const (
+	// KeyLength is the length of the generated API key in bytes (32 bytes = 64 hex chars)
+	KeyLength = 32
+	// KeyPrefixLength is the number of characters to store as prefix for identification
+	KeyPrefixLength = 8
+)
+
+// Handler handles API key requests
+type Handler struct {
+	db *gorm.DB
+}
+
+// NewHandler creates a new API keys handler
+func NewHandler(db *gorm.DB) *Handler {
+	return &Handler{db: db}
+}
+
+// APIKeyResponse represents an API key in responses
+type APIKeyResponse struct {
+	ID          uint       `json:"id"`
+	KeyPrefix   string     `json:"key_prefix"`
+	Description string     `json:"description"`
+	LastUsedAt  *time.Time `json:"last_used_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// CreateAPIKeyRequest represents a request to create an API key
+type CreateAPIKeyRequest struct {
+	Description string `json:"description"`
+}
+
+// CreateAPIKeyResponse includes the full key (only shown once)
+type CreateAPIKeyResponse struct {
+	ID          uint      `json:"id"`
+	Key         string    `json:"key"`
+	KeyPrefix   string    `json:"key_prefix"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// generateAPIKey generates a new random API key
+func generateAPIKey() (string, error) {
+	bytes := make([]byte, KeyLength)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+// hashAPIKey creates a SHA-256 hash of the API key
+func hashAPIKey(key string) string {
+	hash := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(hash[:])
+}
+
+// Create creates a new API key for the authenticated user
+func (h *Handler) Create(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+
+	var req CreateAPIKeyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// Description is optional, so binding might fail with empty body
+		req.Description = ""
+	}
+
+	// Generate the key
+	key, err := generateAPIKey()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate API key"})
+		return
+	}
+
+	// Create the API key record
+	apiKey := models.APIKey{
+		UserID:      userID,
+		KeyHash:     hashAPIKey(key),
+		KeyPrefix:   key[:KeyPrefixLength],
+		Description: req.Description,
+		CreatedByID: userID,
+	}
+
+	if err := h.db.Create(&apiKey).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create API key"})
+		return
+	}
+
+	// Return the full key - this is the only time it's visible
+	c.JSON(http.StatusCreated, CreateAPIKeyResponse{
+		ID:          apiKey.ID,
+		Key:         key,
+		KeyPrefix:   apiKey.KeyPrefix,
+		Description: apiKey.Description,
+		CreatedAt:   apiKey.CreatedAt,
+	})
+}
+
+// List returns all API keys for the authenticated user
+func (h *Handler) List(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+
+	var apiKeys []models.APIKey
+	if err := h.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&apiKeys).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch API keys"})
+		return
+	}
+
+	responses := make([]APIKeyResponse, len(apiKeys))
+	for i, key := range apiKeys {
+		responses[i] = APIKeyResponse{
+			ID:          key.ID,
+			KeyPrefix:   key.KeyPrefix,
+			Description: key.Description,
+			LastUsedAt:  key.LastUsedAt,
+			CreatedAt:   key.CreatedAt,
+		}
+	}
+
+	c.JSON(http.StatusOK, responses)
+}
+
+// Delete deletes an API key
+func (h *Handler) Delete(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	keyID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid API key ID"})
+		return
+	}
+
+	// Find the API key
+	var apiKey models.APIKey
+	if err := h.db.Where("id = ? AND user_id = ?", keyID, userID).First(&apiKey).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "API key not found"})
+		return
+	}
+
+	// Soft delete
+	if err := h.db.Delete(&apiKey).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete API key"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "API key deleted"})
+}
+
+// ValidateAPIKey checks if an API key is valid and returns the user ID
+func ValidateAPIKey(db *gorm.DB, key string) (*models.APIKey, error) {
+	keyHash := hashAPIKey(key)
+
+	var apiKey models.APIKey
+	if err := db.Where("key_hash = ?", keyHash).First(&apiKey).Error; err != nil {
+		return nil, err
+	}
+
+	return &apiKey, nil
+}
+
+// UpdateLastUsed updates the last_used_at timestamp for an API key
+func UpdateLastUsed(db *gorm.DB, apiKeyID uint) {
+	now := time.Now()
+	db.Model(&models.APIKey{}).Where("id = ?", apiKeyID).Update("last_used_at", now)
+}
+
+// CombinedAuthMiddleware returns a middleware that authenticates via JWT or API key
+// Both are passed in the Authorization header as "Bearer <token>"
+// JWTs contain dots, API keys are hex strings without dots
+func CombinedAuthMiddleware(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization header required"})
+			c.Abort()
+			return
+		}
+
+		// Check for Bearer token
+		parts := strings.SplitN(authHeader, " ", 2)
+		if len(parts) != 2 || parts[0] != "Bearer" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid authorization header format"})
+			c.Abort()
+			return
+		}
+
+		token := parts[1]
+
+		// Try JWT first (JWTs contain dots)
+		if strings.Contains(token, ".") {
+			// Validate JWT
+			claims, err := auth.ValidateToken(token)
+			if err != nil {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+				c.Abort()
+				return
+			}
+
+			c.Set("user_id", claims.UserID)
+			c.Set("user_email", claims.Email)
+			c.Set("user_role", claims.SystemRole)
+			c.Next()
+			return
+		}
+
+		// Try API key (hex string without dots)
+		apiKey, err := ValidateAPIKey(db, token)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid API key"})
+			c.Abort()
+			return
+		}
+
+		// Update last used (fire and forget)
+		go UpdateLastUsed(db, apiKey.ID)
+
+		// Set user context
+		c.Set("user_id", apiKey.UserID)
+
+		// Get user to set other context values
+		var user models.User
+		if err := db.First(&user, apiKey.UserID).Error; err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "User not found"})
+			c.Abort()
+			return
+		}
+
+		c.Set("user_email", user.Email)
+		c.Set("user_role", string(user.SystemRole))
+
+		c.Next()
+	}
+}
+
+// RegisterRoutes registers API key routes
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+	rg.POST("/api-keys", h.Create)
+	rg.GET("/api-keys", h.List)
+	rg.DELETE("/api-keys/:id", h.Delete)
+}


### PR DESCRIPTION
## Summary
- Add API key management (create, list, delete) for programmatic access
- Keys are hashed with SHA-256; full key shown only once at creation
- Combined auth middleware accepts either JWT or API key (Bearer token)
- API key usage updates `last_used_at` timestamp asynchronously
- API key management requires JWT (must be logged in to manage keys)
- Other protected routes (groups, links, tags) accept either auth method

## Endpoints
- `POST /api/api-keys` - Create new API key (returns full key once)
- `GET /api/api-keys` - List user's API keys (shows prefix only)
- `DELETE /api/api-keys/:id` - Delete an API key

## Test plan
- [x] `TestCreateAPIKey` - verifies key creation returns full key
- [x] `TestCreateAPIKeyWithoutDescription` - optional description
- [x] `TestListAPIKeys` - lists user's keys with prefix only
- [x] `TestListAPIKeysOnlyShowsOwnKeys` - isolation between users
- [x] `TestDeleteAPIKey` - soft delete works
- [x] `TestDeleteAPIKeyNotOwned` - can't delete others' keys
- [x] `TestValidateAPIKey` - hash validation works
- [x] `TestCombinedAuthMiddleware` - API key auth sets context
- [x] `TestCombinedAuthMiddlewareInvalidKey` - rejects invalid keys
- [x] `TestUpdateLastUsed` - last_used_at tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)