### PR TITLE
Add Pinboard JSON import/export

### DIFF
--- a/cmd/shorty-server/main.go
+++ b/cmd/shorty-server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mikepea/shorty/pkg/shorty/auth"
 	"github.com/mikepea/shorty/pkg/shorty/database"
 	"github.com/mikepea/shorty/pkg/shorty/groups"
+	"github.com/mikepea/shorty/pkg/shorty/importexport"
 	"github.com/mikepea/shorty/pkg/shorty/links"
 	"github.com/mikepea/shorty/pkg/shorty/models"
 	"github.com/mikepea/shorty/pkg/shorty/redirect"
@@ -78,6 +79,10 @@ func main() {
 		// Tags routes (protected - accepts JWT or API key)
 		tagsHandler := tags.NewHandler(database.GetDB())
 		tagsHandler.RegisterRoutes(api.Group("", combinedAuth))
+
+		// Import/Export routes (protected - accepts JWT or API key)
+		importExportHandler := importexport.NewHandler(database.GetDB())
+		importExportHandler.RegisterRoutes(api.Group("", combinedAuth))
 	}
 
 	// Redirect routes (public, must be registered LAST to avoid conflicts)

--- a/pkg/shorty/importexport/handlers.go
+++ b/pkg/shorty/importexport/handlers.go
@@ -1,0 +1,359 @@
+package importexport
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/gorm"
+)
+
+// Handler handles import/export requests
+type Handler struct {
+	db *gorm.DB
+}
+
+// NewHandler creates a new import/export handler
+func NewHandler(db *gorm.DB) *Handler {
+	return &Handler{db: db}
+}
+
+// PinboardBookmark represents a bookmark in Pinboard JSON format
+type PinboardBookmark struct {
+	Href        string `json:"href"`
+	Description string `json:"description"`
+	Extended    string `json:"extended"`
+	Tags        string `json:"tags"`
+	Time        string `json:"time"`
+	Shared      string `json:"shared"`
+	ToRead      string `json:"toread"`
+	Meta        string `json:"meta,omitempty"`
+	Hash        string `json:"hash,omitempty"`
+}
+
+// ImportRequest represents an import request
+type ImportRequest struct {
+	GroupID   uint               `json:"group_id" binding:"required"`
+	Bookmarks []PinboardBookmark `json:"bookmarks" binding:"required"`
+}
+
+// ImportResult represents the result of an import operation
+type ImportResult struct {
+	Imported int      `json:"imported"`
+	Skipped  int      `json:"skipped"`
+	Errors   []string `json:"errors,omitempty"`
+}
+
+// ExportBookmark represents a bookmark for export
+type ExportBookmark struct {
+	Href        string `json:"href"`
+	Description string `json:"description"`
+	Extended    string `json:"extended"`
+	Tags        string `json:"tags"`
+	Time        string `json:"time"`
+	Shared      string `json:"shared"`
+	ToRead      string `json:"toread"`
+}
+
+// checkGroupMembership verifies the user is a member of the group
+func (h *Handler) checkGroupMembership(userID, groupID uint) error {
+	var membership models.GroupMembership
+	if err := h.db.Where("user_id = ? AND group_id = ?", userID, groupID).First(&membership).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+// getUserGroupIDs returns all group IDs the user is a member of
+func (h *Handler) getUserGroupIDs(userID uint) ([]uint, error) {
+	var memberships []models.GroupMembership
+	if err := h.db.Where("user_id = ?", userID).Find(&memberships).Error; err != nil {
+		return nil, err
+	}
+
+	groupIDs := make([]uint, len(memberships))
+	for i, m := range memberships {
+		groupIDs[i] = m.GroupID
+	}
+	return groupIDs, nil
+}
+
+// generateSlug generates a unique slug for a link
+func (h *Handler) generateSlug() (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const length = 8
+
+	for attempts := 0; attempts < 10; attempts++ {
+		slug := make([]byte, length)
+		for i := range slug {
+			slug[i] = charset[time.Now().UnixNano()%int64(len(charset))]
+			time.Sleep(time.Nanosecond)
+		}
+
+		// Check uniqueness
+		var count int64
+		h.db.Model(&models.Link{}).Where("slug = ?", string(slug)).Count(&count)
+		if count == 0 {
+			return string(slug), nil
+		}
+	}
+
+	return "", nil
+}
+
+// Import imports bookmarks from Pinboard JSON format
+func (h *Handler) Import(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+
+	var req ImportRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Check group membership
+	if err := h.checkGroupMembership(userID, req.GroupID); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
+		return
+	}
+
+	result := ImportResult{
+		Errors: []string{},
+	}
+
+	for i, bookmark := range req.Bookmarks {
+		// Parse time
+		var createdAt time.Time
+		if bookmark.Time != "" {
+			parsed, err := time.Parse(time.RFC3339, bookmark.Time)
+			if err != nil {
+				// Try alternative format
+				parsed, err = time.Parse("2006-01-02T15:04:05Z", bookmark.Time)
+				if err != nil {
+					result.Errors = append(result.Errors, "bookmark "+strconv.Itoa(i)+": invalid time format")
+					result.Skipped++
+					continue
+				}
+			}
+			createdAt = parsed
+		} else {
+			createdAt = time.Now()
+		}
+
+		// Generate slug
+		slug, err := h.generateSlug()
+		if err != nil || slug == "" {
+			result.Errors = append(result.Errors, "bookmark "+strconv.Itoa(i)+": failed to generate slug")
+			result.Skipped++
+			continue
+		}
+
+		// Determine visibility
+		isPublic := bookmark.Shared == "yes"
+
+		// Determine unread status
+		isUnread := bookmark.ToRead == "yes"
+
+		// Create link
+		link := models.Link{
+			GroupID:     req.GroupID,
+			CreatedByID: userID,
+			Slug:        slug,
+			URL:         bookmark.Href,
+			Title:       bookmark.Description,
+			Description: bookmark.Extended,
+			IsPublic:    isPublic,
+			IsUnread:    isUnread,
+		}
+		link.CreatedAt = createdAt
+
+		if err := h.db.Create(&link).Error; err != nil {
+			result.Errors = append(result.Errors, "bookmark "+strconv.Itoa(i)+": "+err.Error())
+			result.Skipped++
+			continue
+		}
+
+		// Explicitly update boolean fields to override GORM defaults
+		// GORM applies defaults when values are zero values (false for bools)
+		h.db.Model(&link).Updates(map[string]interface{}{
+			"is_public": isPublic,
+			"is_unread": isUnread,
+		})
+
+		// Handle tags
+		if bookmark.Tags != "" {
+			tagNames := strings.Fields(bookmark.Tags)
+			var tags []models.Tag
+
+			for _, tagName := range tagNames {
+				tagName = strings.TrimSpace(tagName)
+				if tagName == "" {
+					continue
+				}
+
+				var tag models.Tag
+				if err := h.db.Where("name = ?", tagName).First(&tag).Error; err != nil {
+					// Create new tag
+					tag = models.Tag{Name: tagName}
+					if err := h.db.Create(&tag).Error; err != nil {
+						continue
+					}
+				}
+				tags = append(tags, tag)
+			}
+
+			if len(tags) > 0 {
+				h.db.Model(&link).Association("Tags").Append(tags)
+			}
+		}
+
+		result.Imported++
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// Export exports bookmarks to Pinboard JSON format
+func (h *Handler) Export(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+
+	// Get optional group_id parameter
+	groupIDStr := c.Query("group_id")
+	var groupIDs []uint
+
+	if groupIDStr != "" {
+		groupID, err := strconv.ParseUint(groupIDStr, 10, 32)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid group ID"})
+			return
+		}
+
+		// Check membership
+		if err := h.checkGroupMembership(userID, uint(groupID)); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Group not found"})
+			return
+		}
+
+		groupIDs = []uint{uint(groupID)}
+	} else {
+		// Export from all user's groups
+		var err error
+		groupIDs, err = h.getUserGroupIDs(userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch groups"})
+			return
+		}
+	}
+
+	if len(groupIDs) == 0 {
+		c.JSON(http.StatusOK, []ExportBookmark{})
+		return
+	}
+
+	// Fetch links with tags
+	var links []models.Link
+	if err := h.db.Preload("Tags").Where("group_id IN ?", groupIDs).Order("created_at DESC").Find(&links).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch links"})
+		return
+	}
+
+	// Convert to Pinboard format
+	bookmarks := make([]ExportBookmark, len(links))
+	for i, link := range links {
+		// Convert tags to space-separated string
+		tagNames := make([]string, len(link.Tags))
+		for j, tag := range link.Tags {
+			tagNames[j] = tag.Name
+		}
+
+		shared := "no"
+		if link.IsPublic {
+			shared = "yes"
+		}
+
+		toread := "no"
+		if link.IsUnread {
+			toread = "yes"
+		}
+
+		bookmarks[i] = ExportBookmark{
+			Href:        link.URL,
+			Description: link.Title,
+			Extended:    link.Description,
+			Tags:        strings.Join(tagNames, " "),
+			Time:        link.CreatedAt.Format(time.RFC3339),
+			Shared:      shared,
+			ToRead:      toread,
+		}
+	}
+
+	// Set content disposition for download
+	if c.Query("download") == "true" {
+		c.Header("Content-Disposition", "attachment; filename=shorty-export.json")
+	}
+
+	c.JSON(http.StatusOK, bookmarks)
+}
+
+// ExportSingle exports a single link to Pinboard JSON format
+func (h *Handler) ExportSingle(c *gin.Context) {
+	userID, _ := auth.GetUserID(c)
+	slug := c.Param("slug")
+
+	var link models.Link
+	if err := h.db.Preload("Tags").Where("slug = ?", slug).First(&link).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+		return
+	}
+
+	// Check access
+	if !link.IsPublic {
+		if err := h.checkGroupMembership(userID, link.GroupID); err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Link not found"})
+			return
+		}
+	}
+
+	// Convert tags to space-separated string
+	tagNames := make([]string, len(link.Tags))
+	for i, tag := range link.Tags {
+		tagNames[i] = tag.Name
+	}
+
+	shared := "no"
+	if link.IsPublic {
+		shared = "yes"
+	}
+
+	toread := "no"
+	if link.IsUnread {
+		toread = "yes"
+	}
+
+	bookmark := ExportBookmark{
+		Href:        link.URL,
+		Description: link.Title,
+		Extended:    link.Description,
+		Tags:        strings.Join(tagNames, " "),
+		Time:        link.CreatedAt.Format(time.RFC3339),
+		Shared:      shared,
+		ToRead:      toread,
+	}
+
+	c.JSON(http.StatusOK, bookmark)
+}
+
+// RegisterRoutes registers import/export routes
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+	rg.POST("/import", h.Import)
+	rg.GET("/export", h.Export)
+	rg.GET("/export/:slug", h.ExportSingle)
+}
+
+// Ensure json is used (for compile check)
+var _ = json.Marshal

--- a/pkg/shorty/importexport/importexport_test.go
+++ b/pkg/shorty/importexport/importexport_test.go
@@ -1,0 +1,430 @@
+package importexport
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikepea/shorty/pkg/shorty/auth"
+	"github.com/mikepea/shorty/pkg/shorty/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to connect to test database: %v", err)
+	}
+	models.AutoMigrate(db)
+	return db
+}
+
+func createTestUser(t *testing.T, db *gorm.DB, email string) models.User {
+	hash, _ := auth.HashPassword("password123")
+	user := models.User{
+		Email:        email,
+		PasswordHash: hash,
+		Name:         "Test User",
+		SystemRole:   models.SystemRoleUser,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+	return user
+}
+
+func createTestGroup(t *testing.T, db *gorm.DB, name string, userID uint) models.Group {
+	group := models.Group{Name: name}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("Failed to create test group: %v", err)
+	}
+	membership := models.GroupMembership{
+		UserID:  userID,
+		GroupID: group.ID,
+		Role:    models.GroupRoleAdmin,
+	}
+	if err := db.Create(&membership).Error; err != nil {
+		t.Fatalf("Failed to create test membership: %v", err)
+	}
+	return group
+}
+
+func createTestLink(t *testing.T, db *gorm.DB, groupID, userID uint, slug, url string) models.Link {
+	link := models.Link{
+		GroupID:     groupID,
+		CreatedByID: userID,
+		Slug:        slug,
+		URL:         url,
+		Title:       "Test Link",
+		Description: "Test description",
+		IsPublic:    true,
+		IsUnread:    false,
+	}
+	if err := db.Create(&link).Error; err != nil {
+		t.Fatalf("Failed to create test link: %v", err)
+	}
+	return link
+}
+
+func setupTestRouter(db *gorm.DB) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	handler := NewHandler(db)
+
+	api := r.Group("/api")
+	api.Use(auth.AuthMiddleware())
+	handler.RegisterRoutes(api)
+
+	return r
+}
+
+func getAuthHeader(user models.User) string {
+	token, _ := auth.GenerateToken(user.ID, user.Email, string(user.SystemRole))
+	return "Bearer " + token
+}
+
+func TestImportBookmarks(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	req := ImportRequest{
+		GroupID: group.ID,
+		Bookmarks: []PinboardBookmark{
+			{
+				Href:        "https://example.com",
+				Description: "Example Site",
+				Extended:    "This is an example",
+				Tags:        "test example",
+				Time:        "2024-01-15T10:30:00Z",
+				Shared:      "yes",
+				ToRead:      "no",
+			},
+			{
+				Href:        "https://golang.org",
+				Description: "Go Programming",
+				Extended:    "The Go programming language",
+				Tags:        "golang programming",
+				Time:        "2024-01-16T14:00:00Z",
+				Shared:      "no",
+				ToRead:      "yes",
+			},
+		},
+	}
+	jsonBody, _ := json.Marshal(req)
+
+	httpReq, _ := http.NewRequest("POST", "/api/import", bytes.NewBuffer(jsonBody))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var result ImportResult
+	json.Unmarshal(resp.Body.Bytes(), &result)
+
+	if result.Imported != 2 {
+		t.Errorf("Expected 2 imported, got %d", result.Imported)
+	}
+
+	if result.Skipped != 0 {
+		t.Errorf("Expected 0 skipped, got %d", result.Skipped)
+	}
+
+	// Verify links were created
+	var count int64
+	db.Model(&models.Link{}).Where("group_id = ?", group.ID).Count(&count)
+	if count != 2 {
+		t.Errorf("Expected 2 links in database, got %d", count)
+	}
+
+	// Verify tags were created
+	var tagCount int64
+	db.Model(&models.Tag{}).Count(&tagCount)
+	if tagCount != 4 {
+		t.Errorf("Expected 4 tags, got %d", tagCount)
+	}
+}
+
+func TestImportBookmarksNotMember(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	otherUser := createTestUser(t, db, "other@example.com")
+	group := createTestGroup(t, db, "Test Group", otherUser.ID)
+
+	req := ImportRequest{
+		GroupID: group.ID,
+		Bookmarks: []PinboardBookmark{
+			{
+				Href:        "https://example.com",
+				Description: "Example Site",
+			},
+		},
+	}
+	jsonBody, _ := json.Marshal(req)
+
+	httpReq, _ := http.NewRequest("POST", "/api/import", bytes.NewBuffer(jsonBody))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.Code)
+	}
+}
+
+func TestExportBookmarks(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	// Create links with tags
+	link1 := createTestLink(t, db, group.ID, user.ID, "link1", "https://example.com")
+	link2 := createTestLink(t, db, group.ID, user.ID, "link2", "https://golang.org")
+
+	tag1 := models.Tag{Name: "test"}
+	tag2 := models.Tag{Name: "golang"}
+	db.Create(&tag1)
+	db.Create(&tag2)
+	db.Model(&link1).Association("Tags").Append(&tag1)
+	db.Model(&link2).Association("Tags").Append(&tag2)
+
+	httpReq, _ := http.NewRequest("GET", "/api/export", nil)
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var bookmarks []ExportBookmark
+	json.Unmarshal(resp.Body.Bytes(), &bookmarks)
+
+	if len(bookmarks) != 2 {
+		t.Errorf("Expected 2 bookmarks, got %d", len(bookmarks))
+	}
+}
+
+func TestExportBookmarksByGroup(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group1 := createTestGroup(t, db, "Group 1", user.ID)
+	group2 := createTestGroup(t, db, "Group 2", user.ID)
+
+	createTestLink(t, db, group1.ID, user.ID, "link1", "https://example.com")
+	createTestLink(t, db, group2.ID, user.ID, "link2", "https://golang.org")
+
+	// Export only from group1
+	httpReq, _ := http.NewRequest("GET", "/api/export?group_id=1", nil)
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var bookmarks []ExportBookmark
+	json.Unmarshal(resp.Body.Bytes(), &bookmarks)
+
+	if len(bookmarks) != 1 {
+		t.Errorf("Expected 1 bookmark, got %d", len(bookmarks))
+	}
+
+	if bookmarks[0].Href != "https://example.com" {
+		t.Errorf("Expected https://example.com, got %s", bookmarks[0].Href)
+	}
+}
+
+func TestExportSingleBookmark(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	link := createTestLink(t, db, group.ID, user.ID, "test-link", "https://example.com")
+	tag := models.Tag{Name: "test"}
+	db.Create(&tag)
+	db.Model(&link).Association("Tags").Append(&tag)
+
+	httpReq, _ := http.NewRequest("GET", "/api/export/test-link", nil)
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var bookmark ExportBookmark
+	json.Unmarshal(resp.Body.Bytes(), &bookmark)
+
+	if bookmark.Href != "https://example.com" {
+		t.Errorf("Expected https://example.com, got %s", bookmark.Href)
+	}
+
+	if bookmark.Tags != "test" {
+		t.Errorf("Expected 'test' tag, got %s", bookmark.Tags)
+	}
+}
+
+func TestExportSingleBookmarkNotFound(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+
+	httpReq, _ := http.NewRequest("GET", "/api/export/nonexistent", nil)
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.Code)
+	}
+}
+
+func TestExportPrivateLinkNotMember(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	otherUser := createTestUser(t, db, "other@example.com")
+	group := createTestGroup(t, db, "Test Group", otherUser.ID)
+
+	// Create private link
+	link := models.Link{
+		GroupID:     group.ID,
+		CreatedByID: otherUser.ID,
+		Slug:        "private-link",
+		URL:         "https://secret.example.com",
+		Title:       "Private Link",
+		IsPublic:    false,
+	}
+	db.Create(&link)
+
+	httpReq, _ := http.NewRequest("GET", "/api/export/private-link", nil)
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", resp.Code)
+	}
+}
+
+func TestImportPreservesTimestamp(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	req := ImportRequest{
+		GroupID: group.ID,
+		Bookmarks: []PinboardBookmark{
+			{
+				Href:        "https://example.com",
+				Description: "Example Site",
+				Time:        "2020-06-15T10:30:00Z",
+				Shared:      "yes",
+				ToRead:      "no",
+			},
+		},
+	}
+	jsonBody, _ := json.Marshal(req)
+
+	httpReq, _ := http.NewRequest("POST", "/api/import", bytes.NewBuffer(jsonBody))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Verify timestamp was preserved
+	var link models.Link
+	db.Where("group_id = ?", group.ID).First(&link)
+
+	expectedYear := 2020
+	if link.CreatedAt.Year() != expectedYear {
+		t.Errorf("Expected year %d, got %d", expectedYear, link.CreatedAt.Year())
+	}
+}
+
+func TestImportVisibilityAndUnread(t *testing.T) {
+	db := setupTestDB(t)
+	router := setupTestRouter(db)
+	user := createTestUser(t, db, "test@example.com")
+	group := createTestGroup(t, db, "Test Group", user.ID)
+
+	req := ImportRequest{
+		GroupID: group.ID,
+		Bookmarks: []PinboardBookmark{
+			{
+				Href:        "https://public.example.com",
+				Description: "Public Read",
+				Shared:      "yes",
+				ToRead:      "no",
+			},
+			{
+				Href:        "https://private.example.com",
+				Description: "Private Unread",
+				Shared:      "no",
+				ToRead:      "yes",
+			},
+		},
+	}
+	jsonBody, _ := json.Marshal(req)
+
+	httpReq, _ := http.NewRequest("POST", "/api/import", bytes.NewBuffer(jsonBody))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", getAuthHeader(user))
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, httpReq)
+
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Verify first link is public and read
+	var publicLink models.Link
+	db.Where("url = ?", "https://public.example.com").First(&publicLink)
+	if !publicLink.IsPublic {
+		t.Error("Expected public link to be public")
+	}
+	if publicLink.IsUnread {
+		t.Error("Expected public link to not be unread")
+	}
+
+	// Verify second link is private and unread
+	var privateLink models.Link
+	db.Where("url = ?", "https://private.example.com").First(&privateLink)
+	if privateLink.IsPublic {
+		t.Error("Expected private link to not be public")
+	}
+	if !privateLink.IsUnread {
+		t.Error("Expected private link to be unread")
+	}
+}

--- a/tests/integration/server_test.go
+++ b/tests/integration/server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mikepea/shorty/pkg/shorty/apikeys"
 	"github.com/mikepea/shorty/pkg/shorty/auth"
 	"github.com/mikepea/shorty/pkg/shorty/groups"
+	"github.com/mikepea/shorty/pkg/shorty/importexport"
 	"github.com/mikepea/shorty/pkg/shorty/links"
 	"github.com/mikepea/shorty/pkg/shorty/models"
 	"github.com/mikepea/shorty/pkg/shorty/redirect"
@@ -75,6 +76,10 @@ func setupFullServer(db *gorm.DB) *gin.Engine {
 		// Tags routes (protected - accepts JWT or API key)
 		tagsHandler := tags.NewHandler(db)
 		tagsHandler.RegisterRoutes(api.Group("", combinedAuth))
+
+		// Import/Export routes (protected - accepts JWT or API key)
+		importExportHandler := importexport.NewHandler(db)
+		importExportHandler.RegisterRoutes(api.Group("", combinedAuth))
 	}
 
 	// Redirect routes (public, must be registered LAST to avoid conflicts)


### PR DESCRIPTION
## Summary
- Import bookmarks from Pinboard JSON format into a specified group
- Export bookmarks to Pinboard JSON format (all groups or specific group)
- Single bookmark export via slug
- Preserves original timestamps, visibility (shared), and unread status (toread)
- Auto-generates unique slugs for imported links
- Creates new tags or reuses existing ones during import

## Endpoints
- `POST /api/import` - Import bookmarks (requires `group_id` and `bookmarks` array)
- `GET /api/export` - Export all user's bookmarks (optional `?group_id=` filter)
- `GET /api/export/:slug` - Export single bookmark by slug

## Pinboard JSON Format
```json
{
  "href": "https://example.com",
  "description": "Page Title",
  "extended": "Notes/description",
  "tags": "tag1 tag2",
  "time": "2024-01-15T10:30:00Z",
  "shared": "yes",
  "toread": "no"
}
```

## Test plan
- [x] `TestImportBookmarks` - imports multiple bookmarks with tags
- [x] `TestImportBookmarksNotMember` - rejects import to non-member group
- [x] `TestExportBookmarks` - exports links with tags
- [x] `TestExportBookmarksByGroup` - filters export by group
- [x] `TestExportSingleBookmark` - exports single link by slug
- [x] `TestExportSingleBookmarkNotFound` - 404 for missing slug
- [x] `TestExportPrivateLinkNotMember` - 404 for private links user can't access
- [x] `TestImportPreservesTimestamp` - original timestamps preserved
- [x] `TestImportVisibilityAndUnread` - shared/toread flags mapped correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)