### PR TITLE
Split developer docs into focused guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,23 @@ This is a Go project with library/CLI separation and a React frontend:
 - GitHub Actions runs on all PRs and pushes to main
 - Tests must pass before merging
 - CI runs: unit tests, integration tests, Go builds, and React build
+
+## Documentation
+
+Developer documentation lives in `docs/` and should be kept up to date:
+
+| File | Content |
+|------|---------|
+| `docs/developer.md` | Index page linking to all dev guides |
+| `docs/setup.md` | Development environment setup |
+| `docs/backend.md` | Go backend development |
+| `docs/frontend.md` | React frontend development |
+| `docs/diagnosis.md` | Debugging and troubleshooting |
+
+**When to update docs:**
+- Adding new dependencies or tools → update `setup.md`
+- Adding new API endpoints or packages → update `backend.md`
+- Adding new frontend features or test patterns → update `frontend.md`
+- Adding new debugging techniques or common issues → update `diagnosis.md`
+
+Include doc updates in the same PR as the feature when possible.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,0 +1,216 @@
+# Backend Development
+
+This guide covers developing the Go backend for Shorty.
+
+## Project Structure
+
+```
+pkg/shorty/
+├── admin/             # Admin API handlers
+├── apikeys/           # API key authentication
+├── auth/              # User authentication (JWT)
+├── database/          # Database connection
+├── groups/            # Group management
+├── importexport/      # Bulk import/export
+├── links/             # Link management (core feature)
+├── models/            # GORM database models
+├── oidc/              # OIDC/SSO integration
+├── redirect/          # URL redirect handler
+├── scim/              # SCIM 2.0 provisioning
+└── tags/              # Tag management
+```
+
+### Key Packages
+
+| Package | Purpose |
+|---------|---------|
+| `pkg/shorty/models` | Database models and migrations |
+| `pkg/shorty/auth` | JWT authentication and password hashing |
+| `pkg/shorty/links` | Core link shortening logic |
+| `pkg/shorty/scim` | SCIM 2.0 user/group provisioning |
+| `pkg/shorty/oidc` | OpenID Connect SSO |
+
+## Running Tests
+
+### All Backend Tests
+
+```bash
+# Using Make
+make test
+
+# Or directly
+go test -v ./pkg/...
+go test -v ./tests/integration/...
+```
+
+### Specific Package
+
+```bash
+go test -v ./pkg/shorty/links/...
+```
+
+### With Coverage
+
+```bash
+go test -coverprofile=coverage.out ./pkg/...
+go tool cover -html=coverage.out
+```
+
+### Integration Tests with Keycloak
+
+```bash
+INTEGRATION_TEST_KEYCLOAK=1 go test -v ./tests/integration/...
+```
+
+This requires Docker to run a Keycloak container.
+
+## Code Style
+
+- Follow standard Go conventions
+- Use `gofmt` for formatting
+- Run `go vet` before committing
+
+```bash
+gofmt -w .
+go vet ./...
+```
+
+## Adding a New API Endpoint
+
+1. **Create or update the handler** in the appropriate package under `pkg/shorty/`:
+
+```go
+// pkg/shorty/example/handlers.go
+package example
+
+import (
+    "net/http"
+    "github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+    db *gorm.DB
+}
+
+func NewHandler(db *gorm.DB) *Handler {
+    return &Handler{db: db}
+}
+
+// MyEndpoint does something
+// @Summary Short description
+// @Description Longer description
+// @Tags example
+// @Produce json
+// @Success 200 {object} MyResponse
+// @Security BearerAuth
+// @Router /example [get]
+func (h *Handler) MyEndpoint(c *gin.Context) {
+    c.JSON(http.StatusOK, gin.H{"message": "hello"})
+}
+
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+    rg.GET("/example", h.MyEndpoint)
+}
+```
+
+2. **Register routes** in `cmd/shorty-server/main.go`:
+
+```go
+exampleHandler := example.NewHandler(database.GetDB())
+exampleHandler.RegisterRoutes(api.Group("", combinedAuth))
+```
+
+3. **Regenerate Swagger docs**:
+
+```bash
+make generate
+```
+
+4. **Write tests** in `pkg/shorty/example/handlers_test.go`
+
+5. **Update frontend** if needed in `web/src/`
+
+## Adding a New Database Model
+
+1. **Define the model** in `pkg/shorty/models/`:
+
+```go
+// pkg/shorty/models/example.go
+package models
+
+import "gorm.io/gorm"
+
+type Example struct {
+    gorm.Model
+    Name        string `gorm:"not null"`
+    Description string
+    UserID      uint   `gorm:"not null"`
+    User        User   `gorm:"foreignKey:UserID"`
+}
+```
+
+2. **Add to migrations** in `pkg/shorty/models/models.go`:
+
+```go
+func AllModels() []interface{} {
+    return []interface{}{
+        // ... existing models
+        &Example{},
+    }
+}
+```
+
+3. **The migration runs automatically** on server startup.
+
+## API Documentation
+
+### Swagger Annotations
+
+Add Swagger annotations to handler functions:
+
+```go
+// MyHandler does something
+// @Summary Short description
+// @Description Longer description of what this endpoint does
+// @Tags category
+// @Accept json
+// @Produce json
+// @Param id path int true "Resource ID"
+// @Param request body MyRequest true "Request body"
+// @Success 200 {object} MyResponse
+// @Failure 400 {object} map[string]string "Bad request"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Security BearerAuth
+// @Router /resource/{id} [put]
+func (h *Handler) MyHandler(c *gin.Context) {
+    // ...
+}
+```
+
+### Regenerating Documentation
+
+After adding or modifying Swagger annotations:
+
+```bash
+make generate
+```
+
+This updates `api/swagger/swagger.json` and `api/swagger/swagger.yaml`.
+
+### Viewing Documentation
+
+Start the server and visit: `http://localhost:8080/swagger/index.html`
+
+## CI Checks
+
+The CI pipeline runs these backend checks:
+
+1. **Go tests** - Unit and integration tests
+2. **Generate check** - Ensures Swagger docs are up to date
+3. **Build** - Ensures the code compiles
+
+Ensure generated files are up to date before pushing:
+
+```bash
+make check-generate
+```

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,321 +1,32 @@
 # Developer Guide
 
-This guide covers setting up a development environment and contributing to Shorty.
+Welcome to the Shorty developer documentation. This guide will help you set up your development environment and contribute to the project.
 
-## Table of Contents
+## Documentation
 
-- [Prerequisites](#prerequisites)
-- [Development Setup](#development-setup)
-- [Project Structure](#project-structure)
-- [Running Tests](#running-tests)
-- [Code Style](#code-style)
-- [Adding New Features](#adding-new-features)
-- [API Documentation](#api-documentation)
-- [Contributing](#contributing)
+| Guide | Description |
+|-------|-------------|
+| [Setup](setup.md) | Development environment setup, prerequisites, and first run |
+| [Backend](backend.md) | Go backend development, API endpoints, and database models |
+| [Frontend](frontend.md) | React frontend development, testing, and components |
+| [Debugging](diagnosis.md) | Troubleshooting, logging, and diagnostics |
 
-## Prerequisites
-
-- Go 1.25+
-- Node.js 20+
-- Git
-- Make (optional, but recommended)
-
-### Installing Go
+## Quick Start
 
 ```bash
-# macOS with Homebrew
-brew install go
-
-# Or use asdf
-asdf plugin add golang
-asdf install golang 1.25.6
-asdf global golang 1.25.6
-```
-
-### Installing Node.js
-
-```bash
-# macOS with Homebrew
-brew install node@20
-
-# Or use asdf
-asdf plugin add nodejs
-asdf install nodejs 20.10.0
-asdf global nodejs 20.10.0
-```
-
-## Development Setup
-
-### Clone the Repository
-
-```bash
+# Clone and setup
 git clone https://github.com/mikepea/shorty.git
 cd shorty
-```
-
-### Install Development Tools
-
-```bash
 make tools
-```
 
-This installs:
-- `swag` - Swagger documentation generator
-
-### Start the Backend
-
-```bash
+# Start backend (terminal 1)
 go run ./cmd/shorty-server
+
+# Start frontend (terminal 2)
+cd web && npm install && npm run dev
 ```
 
-The server starts on `http://localhost:8080`.
-
-### Start the Frontend (Development Mode)
-
-```bash
-cd web
-npm install
-npm run dev
-```
-
-The frontend starts on `http://localhost:5173` with hot reloading. API requests are proxied to the backend.
-
-### Default Login
-
-- Email: `admin@shorty.local`
-- Password: `changeme`
-
-## Project Structure
-
-```
-shorty/
-├── api/
-│   └── swagger/           # Generated OpenAPI/Swagger docs
-├── cmd/
-│   └── shorty-server/     # Main application entry point
-├── docs/                  # Documentation (you are here)
-├── pkg/shorty/
-│   ├── admin/             # Admin API handlers
-│   ├── apikeys/           # API key authentication
-│   ├── auth/              # User authentication (JWT)
-│   ├── database/          # Database connection
-│   ├── groups/            # Group management
-│   ├── importexport/      # Bulk import/export
-│   ├── links/             # Link management (core feature)
-│   ├── models/            # GORM database models
-│   ├── oidc/              # OIDC/SSO integration
-│   ├── redirect/          # URL redirect handler
-│   ├── scim/              # SCIM 2.0 provisioning
-│   └── tags/              # Tag management
-├── tests/
-│   └── integration/       # Integration tests
-├── web/                   # React frontend
-│   ├── src/
-│   │   ├── api/           # API client
-│   │   ├── components/    # Reusable UI components
-│   │   ├── context/       # React context (auth state)
-│   │   └── pages/         # Page components
-│   └── package.json
-├── Makefile               # Build and development tasks
-├── go.mod                 # Go dependencies
-└── go.sum
-```
-
-### Key Packages
-
-| Package | Purpose |
-|---------|---------|
-| `pkg/shorty/models` | Database models and migrations |
-| `pkg/shorty/auth` | JWT authentication and password hashing |
-| `pkg/shorty/links` | Core link shortening logic |
-| `pkg/shorty/scim` | SCIM 2.0 user/group provisioning |
-| `pkg/shorty/oidc` | OpenID Connect SSO |
-
-## Running Tests
-
-### All Tests
-
-```bash
-# Using Make
-make test
-
-# Or directly
-go test -v ./pkg/...
-go test -v ./tests/integration/...
-```
-
-### Specific Package
-
-```bash
-go test -v ./pkg/shorty/links/...
-```
-
-### With Coverage
-
-```bash
-go test -coverprofile=coverage.out ./pkg/...
-go tool cover -html=coverage.out
-```
-
-### Integration Tests with Keycloak
-
-```bash
-INTEGRATION_TEST_KEYCLOAK=1 go test -v ./tests/integration/...
-```
-
-This requires Docker to run a Keycloak container.
-
-## Code Style
-
-### Go
-
-- Follow standard Go conventions
-- Use `gofmt` for formatting
-- Run `go vet` before committing
-
-```bash
-gofmt -w .
-go vet ./...
-```
-
-### Frontend
-
-- Use TypeScript
-- Follow React best practices
-- Use functional components with hooks
-
-```bash
-cd web
-npm run lint
-```
-
-## Adding New Features
-
-### Adding a New API Endpoint
-
-1. **Create or update the handler** in the appropriate package under `pkg/shorty/`:
-
-```go
-// pkg/shorty/example/handlers.go
-package example
-
-import (
-    "net/http"
-    "github.com/gin-gonic/gin"
-)
-
-type Handler struct {
-    db *gorm.DB
-}
-
-func NewHandler(db *gorm.DB) *Handler {
-    return &Handler{db: db}
-}
-
-// MyEndpoint does something
-// @Summary Short description
-// @Description Longer description
-// @Tags example
-// @Produce json
-// @Success 200 {object} MyResponse
-// @Security BearerAuth
-// @Router /example [get]
-func (h *Handler) MyEndpoint(c *gin.Context) {
-    c.JSON(http.StatusOK, gin.H{"message": "hello"})
-}
-
-func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
-    rg.GET("/example", h.MyEndpoint)
-}
-```
-
-2. **Register routes** in `cmd/shorty-server/main.go`:
-
-```go
-exampleHandler := example.NewHandler(database.GetDB())
-exampleHandler.RegisterRoutes(api.Group("", combinedAuth))
-```
-
-3. **Regenerate Swagger docs**:
-
-```bash
-make generate
-```
-
-4. **Write tests** in `pkg/shorty/example/handlers_test.go`
-
-5. **Update frontend** if needed in `web/src/`
-
-### Adding a New Database Model
-
-1. **Define the model** in `pkg/shorty/models/`:
-
-```go
-// pkg/shorty/models/example.go
-package models
-
-import "gorm.io/gorm"
-
-type Example struct {
-    gorm.Model
-    Name        string `gorm:"not null"`
-    Description string
-    UserID      uint   `gorm:"not null"`
-    User        User   `gorm:"foreignKey:UserID"`
-}
-```
-
-2. **Add to migrations** in `pkg/shorty/models/models.go`:
-
-```go
-func AllModels() []interface{} {
-    return []interface{}{
-        // ... existing models
-        &Example{},
-    }
-}
-```
-
-3. **The migration runs automatically** on server startup.
-
-## API Documentation
-
-### Swagger Annotations
-
-Add Swagger annotations to handler functions:
-
-```go
-// MyHandler does something
-// @Summary Short description
-// @Description Longer description of what this endpoint does
-// @Tags category
-// @Accept json
-// @Produce json
-// @Param id path int true "Resource ID"
-// @Param request body MyRequest true "Request body"
-// @Success 200 {object} MyResponse
-// @Failure 400 {object} map[string]string "Bad request"
-// @Failure 401 {object} map[string]string "Unauthorized"
-// @Security BearerAuth
-// @Router /resource/{id} [put]
-func (h *Handler) MyHandler(c *gin.Context) {
-    // ...
-}
-```
-
-### Regenerating Documentation
-
-After adding or modifying Swagger annotations:
-
-```bash
-make generate
-```
-
-This updates `api/swagger/swagger.json` and `api/swagger/swagger.yaml`.
-
-### Viewing Documentation
-
-Start the server and visit: `http://localhost:8080/swagger/index.html`
+Default login: `admin@shorty.local` / `changeme`
 
 ## Contributing
 
@@ -330,7 +41,11 @@ Start the server and visit: `http://localhost:8080/swagger/index.html`
 
 3. Ensure tests pass:
    ```bash
-   make test
+   # Backend
+   go test -v ./pkg/...
+
+   # Frontend
+   cd web && npm test
    ```
 
 4. Ensure generated files are up to date:
@@ -350,10 +65,6 @@ Start the server and visit: `http://localhost:8080/swagger/index.html`
 Short description of change
 
 Optional longer description if needed.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Your Name <your@email.com>
 ```
 
 ### Pull Request Guidelines
@@ -367,31 +78,33 @@ Co-Authored-By: Your Name <your@email.com>
 
 The CI pipeline runs:
 
-1. **Go tests** - Unit and integration tests
+1. **Backend tests** - Go unit and integration tests
 2. **Generate check** - Ensures Swagger docs are up to date
-3. **Frontend build** - Ensures React app compiles
+3. **Frontend tests** - Vitest unit tests
+4. **Frontend build** - Ensures React app compiles
 
 All checks must pass before merging.
 
-## Debugging
+## Architecture Overview
 
-### Server Logs
-
-The server logs to stdout. Useful log messages include:
-- Database connection status
-- Migration results
-- Request/response logging (in debug mode)
-
-### Database Queries
-
-Enable GORM debug mode to see SQL queries:
-
-```go
-db, _ := gorm.Open(sqlite.Open("test.db"), &gorm.Config{
-    Logger: logger.Default.LogMode(logger.Info),
-})
+```
+┌─────────────────┐     ┌─────────────────┐
+│  React Frontend │────▶│   Go Backend    │
+│  (Vite + TS)    │     │   (Gin + GORM)  │
+└─────────────────┘     └────────┬────────┘
+                                 │
+                        ┌────────▼────────┐
+                        │    SQLite/      │
+                        │   PostgreSQL    │
+                        └─────────────────┘
 ```
 
-### Frontend Debugging
+### Key Technologies
 
-Use React Developer Tools browser extension and the Network tab to debug API calls.
+| Layer | Technology |
+|-------|------------|
+| Frontend | React 19, TypeScript, Vite |
+| Backend | Go 1.25, Gin, GORM |
+| Database | SQLite (dev), PostgreSQL (prod) |
+| Auth | JWT, OIDC/SSO, SCIM 2.0 |
+| Docs | Swagger/OpenAPI |

--- a/docs/diagnosis.md
+++ b/docs/diagnosis.md
@@ -1,0 +1,246 @@
+# Debugging & Diagnostics
+
+This guide covers troubleshooting and debugging techniques for Shorty.
+
+## Server Logs
+
+The server logs to stdout. Useful log messages include:
+- Database connection status
+- Migration results
+- Authentication errors
+- Request/response details (in debug mode)
+
+### Log Levels
+
+By default, the server logs at INFO level. Key log messages:
+
+```
+INFO: Server starting on :8080
+INFO: Database connected
+INFO: Running migrations...
+INFO: OIDC provider configured: google
+```
+
+### Request Logging
+
+Gin's default logger shows all HTTP requests:
+
+```
+[GIN] 2024/01/20 - 10:30:45 | 200 |     1.234ms |    127.0.0.1 | GET     "/api/links"
+[GIN] 2024/01/20 - 10:30:46 | 401 |     0.456ms |    127.0.0.1 | POST    "/api/auth/login"
+```
+
+## Database Debugging
+
+### Enable SQL Query Logging
+
+To see all SQL queries, modify the database connection in `pkg/shorty/database/database.go`:
+
+```go
+import "gorm.io/gorm/logger"
+
+db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+    Logger: logger.Default.LogMode(logger.Info),
+})
+```
+
+This outputs all queries:
+
+```
+[INFO] SELECT * FROM users WHERE id = 1
+[INFO] INSERT INTO links (slug, url, ...) VALUES (?, ?, ...)
+```
+
+### Inspecting SQLite Database
+
+```bash
+# Open the database
+sqlite3 shorty.db
+
+# List tables
+.tables
+
+# Show schema
+.schema users
+.schema links
+
+# Query data
+SELECT * FROM users;
+SELECT slug, url, click_count FROM links LIMIT 10;
+
+# Exit
+.quit
+```
+
+### Common Database Issues
+
+#### "database is locked"
+
+SQLite only allows one writer at a time. This can happen with concurrent requests:
+
+1. Check for long-running transactions
+2. Consider using PostgreSQL for production
+3. Ensure connections are properly closed
+
+#### Migration Failures
+
+If migrations fail on startup:
+
+1. Check the error message for which migration failed
+2. Back up the database
+3. Manually apply or skip the problematic migration
+4. Restart the server
+
+## API Debugging
+
+### Using curl
+
+```bash
+# Login and get token
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@shorty.local","password":"changeme"}' \
+  | jq -r '.token')
+
+# Use token for authenticated requests
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8080/api/links
+
+# Create a link
+curl -X POST http://localhost:8080/api/groups/1/links \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com","title":"Example"}'
+```
+
+### Swagger UI
+
+Interactive API documentation is available at:
+
+```
+http://localhost:8080/swagger/index.html
+```
+
+### Common API Errors
+
+| Status | Error | Cause |
+|--------|-------|-------|
+| 401 | "Authentication required" | Missing or invalid JWT token |
+| 401 | "Invalid email or password" | Wrong login credentials |
+| 403 | "Admin access required" | User lacks admin role |
+| 404 | "Link not found" | Invalid slug or no access |
+| 409 | "Email already registered" | Duplicate registration |
+| 409 | "Slug already exists" | Duplicate link slug |
+
+## Frontend Debugging
+
+### React Developer Tools
+
+Install the [React Developer Tools](https://react.dev/learn/react-developer-tools) browser extension to:
+
+- Inspect component hierarchy
+- View component props and state
+- Profile render performance
+
+### Network Tab
+
+Use the browser's Network tab to debug API calls:
+
+1. Open DevTools (F12)
+2. Go to Network tab
+3. Filter by "Fetch/XHR"
+4. Inspect request/response details
+
+### Common Frontend Issues
+
+#### "Failed to fetch" or CORS errors
+
+The Vite dev server proxies `/api` requests to the backend. Ensure:
+
+1. Backend is running on `http://localhost:8080`
+2. Vite config has correct proxy settings
+3. You're accessing the frontend at `http://localhost:3000`
+
+#### Authentication not persisting
+
+The JWT token is stored in `localStorage`. Check:
+
+1. Token is being saved after login
+2. Token isn't expired
+3. No JavaScript errors preventing storage
+
+```javascript
+// In browser console
+localStorage.getItem('token')
+```
+
+#### State not updating
+
+React state issues can be debugged by:
+
+1. Adding `console.log` in useEffect hooks
+2. Using React DevTools to inspect state
+3. Checking for missing dependency arrays
+
+## OIDC/SSO Debugging
+
+### Test OIDC Flow
+
+1. Check provider configuration:
+   ```bash
+   curl http://localhost:8080/api/oidc/providers
+   ```
+
+2. Verify the callback URL is correct in your IdP settings:
+   ```
+   http://localhost:8080/api/oidc/callback/{provider-slug}
+   ```
+
+3. Check server logs for OIDC errors during authentication
+
+### Common OIDC Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| "Provider not found" | Invalid slug in URL | Check provider slug in database |
+| "Invalid state" | State mismatch | Clear cookies, try again |
+| "Token exchange failed" | Wrong client secret | Verify client_secret in provider config |
+| "User not provisioned" | auto_provision disabled | Enable auto_provision or pre-create user |
+
+## Performance Issues
+
+### Slow API Responses
+
+1. Enable SQL logging to identify slow queries
+2. Check for N+1 query problems (use preloading)
+3. Add database indexes for frequently queried columns
+
+### Memory Usage
+
+Monitor Go memory usage:
+
+```go
+import "runtime"
+
+var m runtime.MemStats
+runtime.ReadMemStats(&m)
+fmt.Printf("Alloc = %v MiB", m.Alloc / 1024 / 1024)
+```
+
+### Frontend Performance
+
+1. Use React DevTools Profiler
+2. Check bundle size with `npm run build`
+3. Lazy load routes for large applications
+
+## Getting Help
+
+If you're stuck:
+
+1. Check existing [GitHub Issues](https://github.com/mikepea/shorty/issues)
+2. Search error messages in the codebase
+3. Review test files for expected behavior
+4. Open a new issue with:
+   - Steps to reproduce
+   - Expected vs actual behavior
+   - Relevant logs/screenshots

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,227 @@
+# Frontend Development
+
+This guide covers developing the React frontend for Shorty.
+
+## Project Structure
+
+```
+web/
+├── src/
+│   ├── api/               # API client and types
+│   │   ├── client.ts      # Fetch wrapper and API methods
+│   │   ├── client.test.ts # API client tests
+│   │   └── types.ts       # TypeScript interfaces
+│   ├── components/        # Reusable UI components
+│   ├── context/           # React context (auth state)
+│   │   ├── AuthContext.tsx
+│   │   └── AuthContext.test.tsx
+│   ├── pages/             # Page components
+│   └── test/              # Test setup
+│       └── setup.ts       # Vitest configuration
+├── package.json
+├── tsconfig.json
+└── vite.config.ts
+```
+
+## Getting Started
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+The dev server runs on `http://localhost:3000` with hot reloading. API requests are proxied to the backend at `http://localhost:8080`.
+
+## Available Scripts
+
+| Script | Description |
+|--------|-------------|
+| `npm run dev` | Start development server |
+| `npm run build` | Build for production |
+| `npm run preview` | Preview production build |
+| `npm run lint` | Run ESLint |
+| `npm test` | Run tests once |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm run test:coverage` | Run tests with coverage |
+
+## Running Tests
+
+The frontend uses [Vitest](https://vitest.dev/) with React Testing Library.
+
+### Run All Tests
+
+```bash
+npm test
+```
+
+### Watch Mode (Development)
+
+```bash
+npm run test:watch
+```
+
+### With Coverage
+
+```bash
+npm run test:coverage
+```
+
+### Test Structure
+
+Tests are co-located with source files:
+
+- `src/api/client.test.ts` - API client tests
+- `src/context/AuthContext.test.tsx` - Auth context tests
+
+### Writing Tests
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('MyComponent', () => {
+  it('renders correctly', () => {
+    render(<MyComponent />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('handles click', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    render(<MyComponent onClick={onClick} />);
+    await user.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalled();
+  });
+});
+```
+
+## Code Style
+
+- Use TypeScript for all new code
+- Follow React best practices
+- Use functional components with hooks
+- Prefer named exports
+
+### Linting
+
+```bash
+npm run lint
+```
+
+## API Client
+
+The API client in `src/api/client.ts` provides typed methods for all backend endpoints:
+
+```typescript
+import { auth, links, groups } from './api/client';
+
+// Authentication
+await auth.login(email, password);
+await auth.register(email, password, name);
+await auth.logout();
+await auth.me();
+await auth.changePassword(currentPassword, newPassword);
+
+// Links
+await links.search({ q: 'query', tag: 'javascript' });
+await links.get('my-slug');
+await links.create(groupId, { url, title });
+await links.update('my-slug', { title: 'New Title' });
+await links.delete('my-slug');
+
+// Groups
+await groups.list();
+await groups.create('Group Name');
+await groups.addMember(groupId, email, 'member');
+```
+
+### Error Handling
+
+The client throws `APIError` for non-2xx responses:
+
+```typescript
+import { APIError } from './api/client';
+
+try {
+  await auth.login(email, password);
+} catch (err) {
+  if (err instanceof APIError) {
+    console.log(err.status);  // HTTP status code
+    console.log(err.message); // Error message from server
+  }
+}
+```
+
+## Auth Context
+
+The `AuthContext` manages authentication state:
+
+```tsx
+import { useAuth } from './context/AuthContext';
+
+function MyComponent() {
+  const { user, isLoading, login, logout } = useAuth();
+
+  if (isLoading) return <div>Loading...</div>;
+  if (!user) return <div>Please log in</div>;
+
+  return (
+    <div>
+      <p>Welcome, {user.name}!</p>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}
+```
+
+### User Object
+
+```typescript
+interface User {
+  id: number;
+  email: string;
+  name: string;
+  system_role: 'admin' | 'user';
+  has_password: boolean;  // false for SSO-only users
+  created_at: string;
+}
+```
+
+## Adding a New Page
+
+1. Create the page component in `src/pages/`:
+
+```tsx
+// src/pages/MyPage.tsx
+export default function MyPage() {
+  return (
+    <div className="my-page">
+      <h1>My Page</h1>
+    </div>
+  );
+}
+```
+
+2. Add the route in `src/App.tsx`:
+
+```tsx
+import MyPage from './pages/MyPage';
+
+// In the Routes:
+<Route path="/my-page" element={<MyPage />} />
+```
+
+3. Add navigation link in `src/components/Sidebar.tsx` if needed.
+
+## CI Checks
+
+The CI pipeline runs these frontend checks:
+
+1. **Tests** - `npm test`
+2. **Build** - `npm run build`
+
+Both must pass before merging.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,99 @@
+# Development Environment Setup
+
+This guide covers setting up your local development environment for Shorty.
+
+## Prerequisites
+
+- Go 1.25+
+- Node.js 20+
+- Git
+- Make (optional, but recommended)
+
+### Installing Go
+
+```bash
+# macOS with Homebrew
+brew install go
+
+# Or use asdf
+asdf plugin add golang
+asdf install golang 1.25.6
+asdf global golang 1.25.6
+```
+
+### Installing Node.js
+
+```bash
+# macOS with Homebrew
+brew install node@20
+
+# Or use asdf
+asdf plugin add nodejs
+asdf install nodejs 20.10.0
+asdf global nodejs 20.10.0
+```
+
+## Clone the Repository
+
+```bash
+git clone https://github.com/mikepea/shorty.git
+cd shorty
+```
+
+## Install Development Tools
+
+```bash
+make tools
+```
+
+This installs:
+- `swag` - Swagger documentation generator
+
+## Start the Backend
+
+```bash
+go run ./cmd/shorty-server
+```
+
+The server starts on `http://localhost:8080`.
+
+## Start the Frontend (Development Mode)
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+The frontend starts on `http://localhost:3000` with hot reloading. API requests are proxied to the backend.
+
+## Default Login
+
+When starting with a fresh database:
+
+- Email: `admin@shorty.local`
+- Password: `changeme`
+
+## Project Structure Overview
+
+```
+shorty/
+├── api/
+│   └── swagger/           # Generated OpenAPI/Swagger docs
+├── cmd/
+│   └── shorty-server/     # Main application entry point
+├── docs/                  # Documentation
+├── pkg/shorty/            # Backend Go packages
+├── tests/
+│   └── integration/       # Integration tests
+├── web/                   # React frontend
+├── Makefile               # Build and development tasks
+├── go.mod                 # Go dependencies
+└── go.sum
+```
+
+## Next Steps
+
+- [Backend Development](backend.md) - Working with Go code
+- [Frontend Development](frontend.md) - Working with React code
+- [Debugging & Diagnostics](diagnosis.md) - Troubleshooting issues


### PR DESCRIPTION
## Summary
Split the monolithic `developer.md` into focused documentation files:

- **setup.md** - Development environment setup and prerequisites
- **backend.md** - Go backend development, API endpoints, database models
- **frontend.md** - React frontend development, testing, components
- **diagnosis.md** - Debugging, logging, and troubleshooting

The main `developer.md` now serves as an index linking to all guides.

## Changes
| File | Description |
|------|-------------|
| `docs/setup.md` | New: Prerequisites, installation, first run |
| `docs/backend.md` | New: Go development, tests, adding endpoints |
| `docs/frontend.md` | New: React development, Vitest testing |
| `docs/diagnosis.md` | New: Debugging, logging, common issues |
| `docs/developer.md` | Updated: Index page with links |

## Test plan
- [x] All links in developer.md are valid
- [x] Content from original file preserved and organized

🤖 Generated with [Claude Code](https://claude.com/claude-code)