### PR TITLE
Add Docker deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Git
+.git
+.gitignore
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# Build artifacts
+*.exe
+shorty-server
+
+# Database files
+*.db
+*.db-journal
+
+# Docs
+docs/
+*.md
+!web/*.md
+
+# Test files
+*_test.go
+tests/
+coverage.out
+
+# Frontend build (we build fresh in Docker)
+web/node_modules
+web/dist
+web/.vite
+
+# Docker
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# CI
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Build Go backend
+FROM golang:1.25-alpine AS backend-builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apk add --no-cache gcc musl-dev
+
+# Download Go dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build
+COPY . .
+RUN CGO_ENABLED=1 go build -o shorty-server ./cmd/shorty-server
+
+# Build React frontend
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app
+
+# Install dependencies
+COPY web/package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY web/ ./
+RUN npm run build
+
+# Final production image
+FROM alpine:3.19
+
+WORKDIR /app
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates tzdata
+
+# Create non-root user
+RUN adduser -D -u 1000 shorty
+USER shorty
+
+# Copy built artifacts
+COPY --from=backend-builder /app/shorty-server .
+COPY --from=frontend-builder /app/dist ./web/dist
+
+# Default environment
+ENV PORT=8080
+ENV GIN_MODE=release
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
+CMD ["./shorty-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  shorty:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - DATABASE_URL=postgres://shorty:shorty@db:5432/shorty?sslmode=disable
+      - JWT_SECRET=change-me-in-production-use-openssl-rand-base64-32
+      - SHORTY_BASE_URL=http://localhost:8080
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=shorty
+      - POSTGRES_PASSWORD=shorty
+      - POSTGRES_DB=shorty
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shorty"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
Add Docker files for containerized deployment:

- **Dockerfile** - Multi-stage build (Go backend + React frontend)
- **docker-compose.yml** - Full stack with PostgreSQL
- **.dockerignore** - Optimized build context
- **Static file serving** - Go server now serves the React SPA

## Usage

```bash
# Build and run with Docker Compose
docker-compose up -d

# Or build image directly
docker build -t shorty .
docker run -p 8080:8080 -e JWT_SECRET=... -e DATABASE_URL=... shorty
```

## Changes
| File | Description |
|------|-------------|
| `Dockerfile` | Multi-stage build: Go 1.25 + Node 20 |
| `docker-compose.yml` | Shorty + PostgreSQL 16 |
| `.dockerignore` | Exclude unnecessary files |
| `cmd/shorty-server/main.go` | Serve frontend from `./web/dist` |

## Test plan
- [x] Go code compiles: `go build ./cmd/shorty-server`
- [x] Go tests pass: `go test ./pkg/...`
- [ ] Docker build succeeds (Docker not available in CI)
- [ ] `docker-compose up` starts both services

🤖 Generated with [Claude Code](https://claude.com/claude-code)