### PR TITLE
Fix Docker setup to use SQLite instead of PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,10 @@ WORKDIR /app
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata
 
-# Create non-root user
-RUN adduser -D -u 1000 shorty
+# Create non-root user and data directory
+RUN adduser -D -u 1000 shorty && \
+    mkdir -p /data && \
+    chown shorty:shorty /data
 USER shorty
 
 # Copy built artifacts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,28 +4,12 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - DATABASE_URL=postgres://shorty:shorty@db:5432/shorty?sslmode=disable
+      - SHORTY_DB_PATH=/data/shorty.db
       - JWT_SECRET=change-me-in-production-use-openssl-rand-base64-32
       - SHORTY_BASE_URL=http://localhost:8080
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: unless-stopped
-
-  db:
-    image: postgres:16-alpine
-    environment:
-      - POSTGRES_USER=shorty
-      - POSTGRES_PASSWORD=shorty
-      - POSTGRES_DB=shorty
     volumes:
-      - postgres_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U shorty"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      - shorty_data:/data
     restart: unless-stopped
 
 volumes:
-  postgres_data:
+  shorty_data:


### PR DESCRIPTION
## Summary
- Remove PostgreSQL service from docker-compose.yml (database package only supports SQLite)
- Use SQLite with persistent volume at /data/shorty.db  
- Create /data directory in Dockerfile with proper ownership for non-root user

## Test plan
- [x] `docker-compose up -d` starts successfully
- [x] Health check returns `{"status":"ok"}`
- [x] Frontend served at http://localhost:8080/
- [x] Database persists in volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)